### PR TITLE
Report which sessions have a turn running

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1133,7 +1133,15 @@ app.post('/api/download/cancel', (req, res) => {
 })
 
 // ---------- sessions ----------
-app.get('/api/sessions', (req, res) => res.json(listSessions()))
+// `active` reports whether a turn is streaming for this session right now.
+// activeTurns is in-memory, so until this landed nothing outside the process
+// could tell a working session from an idle one — a status board could list
+// every session but not which of them were actually running.
+app.get('/api/sessions', (req, res) => res.json(listSessions().map(s => ({ ...s, active: activeTurns.has(s.id) }))))
+
+// Just the live set, for pollers that want a cheap answer rather than every
+// session on disk. Reading it costs nothing, so it is safe on a short interval.
+app.get('/api/active', (req, res) => res.json({ active: [...activeTurns.keys()], count: activeTurns.size }))
 
 app.post('/api/sessions', (req, res) => {
   const agent = req.body.agentId ? (config.agents || []).find(a => a.id === req.body.agentId) : null


### PR DESCRIPTION
`activeTurns` already tracks every streaming turn, but it lives in memory and nothing exposes it. `/api/sessions` can list every session while leaving a caller unable to tell a working one from an idle one, which is the single thing a status board most wants to know.

**Two additions, no behavior change:**

- `/api/sessions` gains an `active` boolean per session.
- `/api/active` returns just the live ids and a count, for pollers that don't want to read every session off disk to answer one question.

Both read the existing map and allocate nothing per request, so polling either on a short interval is cheap. Existing consumers see one extra field and are otherwise unaffected.

### Why

I wired Radiant into a local dashboard that already tracks Claude Code and Codex sessions. Those are processes, so `ps` finds them and their state is obvious. A Radiant session is a chat inside one long-lived app process, so an API is the only way to see it at all — and without `active`, every session looks the same whether it's mid-stream or three weeks old.

The consumer degrades gracefully against a build without this: a missing `active` reads as "not live" rather than erroring. But then the board can only ever show sessions, never activity.

### Testing

Ran `node server/index.js` on this branch and confirmed `/api/active` returns `{"active":[],"count":0}` when idle, and that every object from `/api/sessions` carries the new field.

I did not touch the `GUIDE` array in `src/components/Settings.jsx` — this adds no user-facing surface, only two endpoints. Happy to add a line there if you'd rather it be mentioned.
