### PR TITLE
Archive a session instead of destroying it

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -321,11 +321,11 @@ export function listSessions () {
     .map(f => {
       try {
         const s = JSON.parse(fs.readFileSync(path.join(SESSIONS_DIR, f), 'utf8'))
-        return { id: s.id, title: s.title, model: s.model, provider: s.provider, cwd: s.cwd, agentId: s.agentId || null, projectId: s.projectId || null, pinned: Boolean(s.pinned), updatedAt: s.updatedAt, messageCount: s.messages.length }
+        return { id: s.id, title: s.title, model: s.model, provider: s.provider, cwd: s.cwd, agentId: s.agentId || null, projectId: s.projectId || null, pinned: Boolean(s.pinned), archived: Boolean(s.archived), updatedAt: s.updatedAt, messageCount: s.messages.length }
       } catch { return null }
     })
     .filter(Boolean)
-    .sort((a, b) => (b.pinned - a.pinned) || (b.updatedAt || '').localeCompare(a.updatedAt || ''))
+    .sort((a, b) => (a.archived - b.archived) || (b.pinned - a.pinned) || (b.updatedAt || '').localeCompare(a.updatedAt || ''))
 }
 
 // Full-text search across all past sessions (title + message text).
@@ -365,6 +365,9 @@ export function saveSession (session) {
   fs.writeFileSync(path.join(SESSIONS_DIR, session.id + '.json'), JSON.stringify(session, null, 2))
 }
 
+// Permanent: unlinks the transcript, every message and every tool call with it.
+// There is no undo and no trash. The sidebar reaches this only from the archive,
+// behind its own confirm — archiving is what a session row's ✕ does.
 export function deleteSession (id) {
   if (!/^[a-z0-9-]+$/.test(id)) return
   try { fs.unlinkSync(path.join(SESSIONS_DIR, id + '.json')) } catch {}

--- a/server/index.js
+++ b/server/index.js
@@ -1404,7 +1404,7 @@ app.get('/api/sessions/:id', (req, res) => {
 app.patch('/api/sessions/:id', (req, res) => {
   const s = loadSession(req.params.id)
   if (!s) return res.status(404).json({ error: 'not found' })
-  for (const k of ['title', 'model', 'provider', 'cwd', 'useTools', 'computerControl', 'agentId', 'projectId', 'pinned', 'planMode']) {
+  for (const k of ['title', 'model', 'provider', 'cwd', 'useTools', 'computerControl', 'agentId', 'projectId', 'pinned', 'archived', 'planMode']) {
     if (k in req.body) s[k] = req.body[k]
   }
   if ('title' in req.body) s.autoTitle = false // manual rename pins the title

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -184,6 +184,16 @@ function DesktopApp () {
     refreshSessions()
   }
 
+  // Archiving is what the sidebar's ✕ does. It hides the session and nothing
+  // more — the transcript stays on disk and stays searchable, so getting it
+  // back is one click rather than impossible. Deleting is a separate act,
+  // reachable only from inside the archive.
+  const archiveSession = async (id, archived) => {
+    await api.patchSession(id, { archived })
+    if (archived && session?.id === id) setSession(null)
+    refreshSessions()
+  }
+
   const patchSession = async patch => {
     if (!session) return
     const s = await api.patchSession(session.id, patch)
@@ -333,6 +343,7 @@ function DesktopApp () {
         onNewGroup={() => { setGroupPickerOpen(true); setNavOpen(false) }}
         onCloseNav={() => setNavOpen(false)}
         onDelete={removeSession}
+        onArchive={archiveSession}
         onRename={renameSession}
         onPin={pinSession}
         agents={config.agents || []}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -72,7 +72,7 @@ function UsageChip () {
 const MIN_W = 190
 const MAX_W = 460
 
-export default function Sidebar ({ sessions, activeId, working, onOpen, onNew, onNewGroup, onDelete, onRename, onPin, agents = [], projects = [], onNewProject, onRenameProject, onDeleteProject, onMoveSession, onSettings, mode, onToggleMode, updateInfo, onUpdate, onCloseNav }) {
+export default function Sidebar ({ sessions, activeId, working, onOpen, onNew, onNewGroup, onDelete, onArchive, onRename, onPin, agents = [], projects = [], onNewProject, onRenameProject, onDeleteProject, onMoveSession, onSettings, mode, onToggleMode, updateInfo, onUpdate, onCloseNav }) {
   const agentOf = id => agents.find(a => a.id === id)
   const [width, setWidth] = useState(() => {
     const saved = Number(localStorage.getItem('radiant.sidebarWidth'))
@@ -119,16 +119,21 @@ export default function Sidebar ({ sessions, activeId, working, onOpen, onNew, o
     return () => clearTimeout(t)
   }, [search])
 
+  // Archived sessions leave every normal list and gather in their own section.
+  const live = React.useMemo(() => sessions.filter(s => !s.archived), [sessions])
+  const archived = React.useMemo(() => sessions.filter(s => s.archived), [sessions])
+  const [showArchive, setShowArchive] = useState(false)
+
   // Grouped once per render rather than filtered inside the map, so a sidebar
   // with a few hundred chats does not walk the list once per project.
   const projectGroups = React.useMemo(() => {
     const byId = new Map(projects.map(p => [p.id, []]))
-    for (const s of sessions) if (s.projectId && byId.has(s.projectId)) byId.get(s.projectId).push(s)
+    for (const s of live) if (s.projectId && byId.has(s.projectId)) byId.get(s.projectId).push(s)
     return projects.map(p => ({ project: p, rows: byId.get(p.id) || [] }))
-  }, [projects, sessions])
+  }, [projects, live])
   const loose = React.useMemo(
-    () => sessions.filter(s => !s.projectId || !projects.some(p => p.id === s.projectId)),
-    [sessions, projects]
+    () => live.filter(s => !s.projectId || !projects.some(p => p.id === s.projectId)),
+    [live, projects]
   )
 
   // ⚠️ NEVER window.prompt() IN THIS APP. It is a no-op in Electron — the
@@ -203,7 +208,14 @@ export default function Sidebar ({ sessions, activeId, working, onOpen, onNew, o
           )}
           <button title={s.pinned ? 'Unpin' : 'Pin to top'} onClick={e => { e.stopPropagation(); onPin(s.id, !s.pinned) }}>{s.pinned ? '★' : '☆'}</button>
           <button title='Rename' onClick={e => { e.stopPropagation(); setEditing({ kind: 'session', id: s.id, value: s.title }) }}>✎</button>
-          <button title='Delete' onClick={e => { e.stopPropagation(); if (window.confirm(`Delete "${s.title}"?`)) onDelete(s.id) }}>✕</button>
+          {s.archived
+            ? <>
+                <button title='Restore from archive' onClick={e => { e.stopPropagation(); onArchive(s.id, false) }}>⤺</button>
+                {/* The only route to a real delete. Everything it removes is
+                    unrecoverable, so it says so and names the session. */}
+                <button title='Delete permanently' onClick={e => { e.stopPropagation(); if (window.confirm(`Permanently delete "${s.title}"?\n\nThis erases the whole transcript — every message and tool call — from disk. It cannot be undone.`)) onDelete(s.id) }}>🗑</button>
+              </>
+            : <button title='Archive' onClick={e => { e.stopPropagation(); onArchive(s.id, true) }}>✕</button>}
         </div>
       </div>
     )
@@ -309,17 +321,32 @@ export default function Sidebar ({ sessions, activeId, working, onOpen, onNew, o
             )}
             {/* Before the first project exists there is nothing to group by, so
                 the list stays exactly as it was. */}
-            {!projects.length && sessions.map(s => <SessionRow key={s.id} s={s} />)}
+            {!projects.length && live.map(s => <SessionRow key={s.id} s={s} />)}
             {/* Only when there are no shelves to speak for themselves. With
                 projects present each one already says "No chats yet.", and this
                 line underneath them said the same thing a third time. */}
-            {!sessions.length && !projects.length && <div style={{ padding: '10px 12px', color: 'var(--text-faint)', fontSize: 12 }}>No sessions yet.</div>}
+            {!live.length && !projects.length && <div style={{ padding: '10px 12px', color: 'var(--text-faint)', fontSize: 12 }}>No sessions yet.</div>}
+            {/* Archive: collapsed by default and last in the list, so it stays
+                out of the way but the sessions remain reachable — and remain
+                findable by search, which reads from disk regardless. */}
+            {archived.length > 0 && (
+              <div className='bot-group'>
+                <div className='bot-head'>
+                  <button className='bot-head-toggle' onClick={() => setShowArchive(v => !v)} title={showArchive ? 'Hide archived' : 'Show archived'}>
+                    <span className='bot-head-caret'>{showArchive ? '▾' : '▸'}</span>
+                    <span className='bot-head-name' style={{ color: 'var(--text-faint)' }}>Archived</span>
+                    <span className='bot-head-count'>{archived.length}</span>
+                  </button>
+                </div>
+                {showArchive && archived.map(s => <SessionRow key={s.id} s={s} />)}
+              </div>
+            )}
           </>}
         </div>
       ) : (
         <div className='session-list'>
           {[...agents].sort((x, y) => Number(isImported(x)) - Number(isImported(y))).map((a, i, list) => {
-            const own = sessions.filter(s => s.agentId === a.id)
+            const own = live.filter(s => s.agentId === a.id)
             const isCollapsed = collapsed[a.id]
             // first imported agent in the list opens the "from other apps" group
             const startsImported = isImported(a) && !(i > 0 && isImported(list[i - 1]))
@@ -350,7 +377,7 @@ export default function Sidebar ({ sessions, activeId, working, onOpen, onNew, o
               </React.Fragment>
             )
           })}
-          {(() => { const orphans = sessions.filter(s => !agentOf(s.agentId)); return orphans.length > 0 && (
+          {(() => { const orphans = live.filter(s => !agentOf(s.agentId)); return orphans.length > 0 && (
             <div className='bot-group'>
               <div className='bot-head'><span className='bot-head-name' style={{ color: 'var(--text-faint)' }}>No agent</span><span className='bot-head-count'>{orphans.length}</span></div>
               {orphans.map(s => <SessionRow key={s.id} s={s} />)}


### PR DESCRIPTION
The ✕ on a session row calls `deleteSession`, which is `fs.unlinkSync` on the transcript — every message and tool call, gone, with no trash and no undo. The only thing between a long session and nothing is one `window.confirm`, on a button sitting flush against pin and rename in a 248px row. Misclick, Enter, gone.

I noticed because I'd left a multi-hour code review in a session and realised how close that ✕ was to the paperclip.

### What changes

**✕ archives.** The session leaves the sidebar, keeps its file, and gathers in an **Archived** group at the bottom of the list, collapsed by default. Restoring is one click (`⤺`).

**Delete still exists and is still permanent** — it just moved. A `🗑` appears only on rows inside the archive, behind a confirm that names the session and says plainly what is being erased.

**Archived sessions stay searchable.** `search_sessions` and `/api/sessions-search` read from disk, so they keep finding them. That's the point of keeping them — an agent's recall of past work shouldn't depend on whether the row is visible.

### Implementation

- `listSessions` reports `archived`, and sorts archived rows below everything else, so the flag still does something in any view that doesn't draw the group.
- `PATCH /api/sessions/:id` accepts `archived`, exactly like `pinned`.
- The sidebar's project groups, agent groups and flat list all read a `live` list, so an archived session can't leak back in through another view.
- No migration needed: a session with no field reads as not archived.

Four files, +54/−13. No new dependencies, no new concepts beyond a boolean.

### Testing

Round-tripped against a running server: archive sets the flag and drops the row, the file stays in `~/.radiant/sessions/`, `sessions-search` still returns it, restore brings it back, and `messageCount` is unchanged throughout. Built clean.

I avoided `window.prompt` per the warning in `Sidebar.jsx` — the two new controls are a button and a `confirm`, both of which work in Electron.

One judgement call worth your view: I kept ✕ as the archive glyph since it reads as "get this off my list", which is what people mean when they click it. If you'd rather it were an explicit archive icon and ✕ meant something else, easy to change.
