### PR TITLE
Add Anthropic prompt caching to the Claude provider path

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3022,7 +3022,16 @@ app.post('/api/chat', async (req, res) => {
 
   // lead/worker: if this agent has a planner model, have the (stronger) lead model
   // outline the approach first; the (session) model then executes it.
-  let plannedPersona = agent?.persona || ''
+  //
+  // ⚠️ THE PLAN TEXT IS PER-TURN, THE PERSONA ISN'T. `plan` is regenerated fresh
+  // from `text` (this turn's request) every time this branch runs, so it must
+  // travel to providers.js as `planAddendum` (the volatile half of the system
+  // prompt), not folded into `persona` (the stable half) — see providers.js's
+  // systemPrompt() comment. Folding it into persona was the original prompt-
+  // caching bug: it made the "stable" system block change on every turn a
+  // plannerModel was configured.
+  const basePersona = agent?.persona || ''
+  let planAddendum = ''
   if (agent?.plannerModel && agent?.plannerProvider && session.useTools !== false && !session.group) {
     const pProvider = config.providers.find(p => p.id === agent.plannerProvider)
     if (pProvider) {
@@ -3040,7 +3049,7 @@ app.post('/api/chat', async (req, res) => {
           requestApproval: null, signal: controller.signal
         })
       } catch {}
-      if (plan.trim()) plannedPersona = `${plannedPersona}\n\n[A lead model has planned the approach below — follow it, adapting as needed:]\n${plan.trim()}`
+      if (plan.trim()) planAddendum = `[A lead model has planned the approach below — follow it, adapting as needed:]\n${plan.trim()}`
     }
   }
 
@@ -3055,6 +3064,8 @@ app.post('/api/chat', async (req, res) => {
     summarize,
     autoCompact: config.settings.autoCompact !== false,
     autoApproveComputer: config.settings.fullAutomation === true,
+    cachingEnabled: config.settings.promptCaching !== false,
+    cacheTtl: config.settings.cacheTtl === '1h' ? '1h' : '5m',
     mcpTools,
     callMcp,
     emit,
@@ -3082,7 +3093,8 @@ app.post('/api/chat', async (req, res) => {
         ...common,
         useTools: session.useTools !== false,
         computerControl: Boolean(session.computerControl),
-        persona: plannedPersona,
+        persona: basePersona,
+        planAddendum,
         skills: mergedSkills,
         askAgent,
         peerAgents,

--- a/server/providers.js
+++ b/server/providers.js
@@ -39,23 +39,52 @@ const MAX_TURN_TOKENS = Number(process.env.RADIANT_MAX_TURN_TOKENS || 12_000_000
 // the same call after that, it is not going to stop on its own.
 const STUCK_AT = 12
 
-function systemPrompt (cwd, useTools, model, computerControl, skills, persona, planMode, memory) {
+// Split into a STABLE half (identical across turns unless the user explicitly
+// reconfigures the session — persona, skills, cwd, tool/plan/computer-control
+// toggles) and a VOLATILE half (recomputed fresh from the CURRENT turn's input,
+// so it is essentially guaranteed to differ every request): retrieved memory
+// facts (relevantFacts() is scored against this turn's user text — see
+// server/memory.js) and the lead-model plan addendum (regenerated per turn when
+// an agent has a plannerModel). Putting volatile content in the system array
+// AFTER a cache_control-marked stable block keeps the marked prefix byte-
+// identical across turns without touching the volatile content's visibility —
+// see the claude-api skill's shared/prompt-caching.md, "Architectural guidance"
+// + "Multi-turn conversations". A stable-half change (e.g. the user flips
+// planMode or edits skills) is a one-time cache miss, not a per-turn one — that
+// tradeoff is deliberate, not the bug this split fixes.
+function systemPrompt (cwd, useTools, model, computerControl, skills, persona, planMode, planAddendum, memory) {
   const personaText = persona ? `\n\n${persona}` : ''
-  const memoryText = (memory && memory.length)
-    ? `\n\nWhat you remember about this user and their projects (from past sessions — use it when relevant, don't recite it):\n${memory.map(f => `• ${f}`).join('\n')}`
-    : ''
   const planText = planMode
     ? '\n\nPLAN MODE IS ON. Do NOT edit files, create files, or run mutating commands yet. Research the codebase (read/list/grep only), think through the approach, then present a concrete step-by-step plan by calling the exit_plan_mode tool with your plan in markdown. Only after the user approves the plan will you be able to make changes.'
     : ''
   const skillText = (skills && skills.length)
     ? `\n\nActive skills (follow these):\n${skills.map(s => `• ${s.name}: ${s.content}${s.dir && resolveSkillDir(s.dir) ? `\n  Skill folder: ${resolveSkillDir(s.dir)}` : ''}`).join('\n')}`
     : ''
-  return `You are a coding agent running inside Radiant, a local coding harness on the user's ${os.type() === 'Darwin' ? 'Mac' : os.type()} (${os.platform()} ${os.release()}). Radiant is the app, not you: you are the model "${model}". If asked what model you are, answer with your actual model name and maker.${personaText}
+  const stable = `You are a coding agent running inside Radiant, a local coding harness on the user's ${os.type() === 'Darwin' ? 'Mac' : os.type()} (${os.platform()} ${os.release()}). Radiant is the app, not you: you are the model "${model}". If asked what model you are, answer with your actual model name and maker.${personaText}
 Workspace directory: ${cwd}
 ${useTools ? 'You have tools to read, write, and edit files and to run shell commands in the workspace. Use them to investigate before answering and to make changes when asked. Prefer edit_file for small changes and write_file for new files. After making changes, verify them when practical (run the code, run tests).' : 'Tools are disabled for this conversation; answer from knowledge and the conversation only.'}${computerControl ? `
 You can also control the computer. browser_* tools drive an automated browser; screen_* tools control the whole desktop. ALWAYS take a screenshot first (browser_screenshot / screen_screenshot) and look at it before clicking or typing — click coordinates are pixel positions read from the most recent screenshot. Work in small steps: screenshot, act, screenshot again to confirm. Prefer browser_* for web tasks.` : ''}
-Be direct and concise. Use markdown; fence code blocks with a language tag. When you finish a task, summarize what changed in a sentence or two.${planText}${skillText}${memoryText}`
+Be direct and concise. Use markdown; fence code blocks with a language tag. When you finish a task, summarize what changed in a sentence or two.${planText}${skillText}`
+
+  const planAddendumText = planAddendum ? `\n\n${planAddendum}` : ''
+  const memoryText = (memory && memory.length)
+    ? `\n\nWhat you remember about this user and their projects (from past sessions — use it when relevant, don't recite it):\n${memory.map(f => `• ${f}`).join('\n')}`
+    : ''
+  const volatile = `${planAddendumText}${memoryText}`
+
+  return { stable, volatile, full: stable + volatile }
 }
+
+// Very rough token estimate (chars/4) used only to decide whether the stable
+// system prefix clears a model's minimum cacheable length — see
+// shared/prompt-caching.md's per-model minimum table (512-4096 tokens,
+// non-monotonic across generations). Radiant supports arbitrary/rolling model
+// ids across many Anthropic-compatible endpoints, so there's no reliable way to
+// look up an exact per-model number here; 1024 is a conservative mid-table
+// default that a real coding-agent system prompt (identity + tool
+// instructions + persona/skills) almost always clears anyway.
+const MIN_CACHEABLE_TOKENS = 1024
+function roughTokens (text) { return Math.round((text || '').length / 4) }
 
 // ---------- internal message format -> provider wire formats ----------
 // session.messages: [{role:'user', text, attachments} | {role:'assistant', parts:[{type:'text',text}|{type:'tool',id,name,args,result}]}]
@@ -281,17 +310,34 @@ export const EFFORTS = ['auto', 'low', 'medium', 'high']
 // its own, so max_tokens is raised alongside rather than eaten into.
 const THINK_BUDGET = { low: 2048, medium: 6144, high: 12288 }
 
-async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, system, tools, toolDefs, effort, emit, signal }) {
+async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, systemStable, systemVolatile, tools, toolDefs, effort, cachingEnabled, cacheTtl, emit, signal }) {
   // Subscription (OAuth) requests must present as Claude Code: the first system
   // block is the CLI's identity, auth is Bearer, and the oauth beta is set.
   const CLAUDE_CODE_ID = "You are Claude Code, Anthropic's official CLI for Claude."
-  // Prompt caching: mark the last system block cacheable. Anthropic renders
-  // tools -> system -> messages, so a breakpoint on the last system block caches
-  // the tool definitions too — no separate marker needed on `tools`. System must
-  // be block form (not a bare string) for cache_control to attach.
-  const sys = accessToken
-    ? [{ type: 'text', text: CLAUDE_CODE_ID }, { type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
-    : [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
+  // Prompt caching, on by default (Settings → caching toggle) but skippable —
+  // some Anthropic-compatible baseUrls reject cache_control, and single-shot
+  // (non-conversational) turns get zero benefit from a cache write.
+  // ⚠️ ONLY THE STABLE HALF GETS THE MARKER. Anthropic renders tools -> system
+  // -> messages, so a breakpoint on the last block of the stable system text
+  // caches tool definitions too. The volatile half (memory / plan addendum —
+  // see systemPrompt()'s comment) is appended as a SEPARATE, unmarked system
+  // block after it: still sent every turn, but its churn can't invalidate the
+  // marked prefix before it. System must be block form (not a bare string) for
+  // cache_control to attach.
+  // Anthropic renders tools BEFORE system, and a breakpoint on the last system
+  // block caches both together — so the minimum-cacheable-length check has to
+  // count tool definitions too, not just the (often short on its own) stable
+  // system text. Measuring systemStable alone under-counts the real prefix and
+  // wrongly skips caching on a normal tool-using turn.
+  const toolDefsForBody = tools ? (toolDefs || TOOL_DEFS).map(t => ({ name: t.name, description: t.description, input_schema: t.input_schema })) : null
+  const prefixTokens = roughTokens(systemStable) + (toolDefsForBody ? roughTokens(JSON.stringify(toolDefsForBody)) : 0)
+  const useCaching = cachingEnabled !== false && prefixTokens >= MIN_CACHEABLE_TOKENS
+  const cacheControl = useCaching ? { type: 'ephemeral', ...(cacheTtl === '1h' ? { ttl: '1h' } : {}) } : null
+  const sys = accessToken ? [{ type: 'text', text: CLAUDE_CODE_ID }] : []
+  sys.push(cacheControl
+    ? { type: 'text', text: systemStable, cache_control: cacheControl }
+    : { type: 'text', text: systemStable })
+  if (systemVolatile) sys.push({ type: 'text', text: systemVolatile })
   const body = { model, max_tokens: 8192, system: sys, messages, stream: true }
   // ⚠️ RAISE max_tokens WITH THE BUDGET, do not carve the budget out of it — the
   // thinking budget and the visible reply share this number, so a 12k budget under
@@ -301,28 +347,22 @@ async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, 
     body.thinking = { type: 'enabled', budget_tokens: THINK_BUDGET[effort] }
     body.max_tokens = 8192 + THINK_BUDGET[effort]
   }
-  if (tools) body.tools = (toolDefs || TOOL_DEFS).map(t => ({ name: t.name, description: t.description, input_schema: t.input_schema }))
-  // Second cache breakpoint on the tail of the growing conversation: each new
-  // turn reuses everything before this message from cache, and the marker walks
-  // forward as history grows (Anthropic's documented multi-turn placement
-  // pattern). Non-mutating — toAnthropic() builds fresh objects per call.
-  if (messages.length) {
-    const lastMsg = messages[messages.length - 1]
-    if (Array.isArray(lastMsg.content) && lastMsg.content.length) {
-      const i = lastMsg.content.length - 1
-      messages = [
-        ...messages.slice(0, -1),
-        { ...lastMsg, content: [...lastMsg.content.slice(0, i), { ...lastMsg.content[i], cache_control: { type: 'ephemeral' } }] }
-      ]
-      body.messages = messages
-    }
-  }
+  if (toolDefsForBody) body.tools = toolDefsForBody
+  // Top-level automatic caching covers the growing conversation tail: Anthropic
+  // places (and walks forward) its own breakpoint on the last cacheable message
+  // block, which is the documented default for multi-turn conversations and
+  // avoids hand-tracking positions against the 20-block lookback window
+  // ourselves (shared/prompt-caching.md, "Automatic vs explicit breakpoints" +
+  // "The robust combination for agent loops"). Composes with the explicit
+  // system-block marker above (2 of the 4 available breakpoint slots used).
+  if (useCaching && messages.length) body.cache_control = cacheControl
   const headers = { 'content-type': 'application/json', 'anthropic-version': '2023-06-01' }
   if (accessToken) {
     headers.authorization = `Bearer ${accessToken}`
-    headers['anthropic-beta'] = 'oauth-2025-04-20,claude-code-20250219'
+    headers['anthropic-beta'] = ['oauth-2025-04-20', 'claude-code-20250219', ...(cacheTtl === '1h' ? ['extended-cache-ttl-2025-04-11'] : [])].join(',')
   } else {
     headers['x-api-key'] = apiKey
+    if (cacheTtl === '1h') headers['anthropic-beta'] = 'extended-cache-ttl-2025-04-11'
   }
   const res = await fetch(`${baseUrl}/v1/messages`, {
     method: 'POST',
@@ -632,11 +672,11 @@ function planBlocked (name) {
 }
 
 // ---------- the agent loop ----------
-export async function runTurn ({ provider, model, apiKey, getAccessToken, getAccountId, session, useTools, computerControl, skills, persona, memory, agentId, groupSpeakerId, groupNames, mcpTools, callMcp, askAgent, peerAgents, planMode, onPlanExit, effort, summarize, autoCompact, autoApproveComputer, emit, requestApproval, requestUserChoice, signal }) {
+export async function runTurn ({ provider, model, apiKey, getAccessToken, getAccountId, session, useTools, computerControl, skills, persona, planAddendum, memory, agentId, groupSpeakerId, groupNames, mcpTools, callMcp, askAgent, peerAgents, planMode, onPlanExit, effort, summarize, autoCompact, autoApproveComputer, cachingEnabled, cacheTtl, emit, requestApproval, requestUserChoice, signal }) {
   // ⚠️ NOT `session.cwd || os.homedir()`. A folder that is set and not here is
   // the case that broke every tool call in the chat — see usableCwd.
   const { dir: cwd, missing: strayCwd } = usableCwd(session.cwd)
-  const system = systemPrompt(cwd, useTools, model, computerControl, skills, persona, planMode, memory)
+  const system = systemPrompt(cwd, useTools, model, computerControl, skills, persona, planMode, planAddendum, memory)
   // proactive compaction before a very long turn
   if (autoCompact && summarize && estimateTokens(session.messages) > PROACTIVE_TOKENS) {
     await compactSession(session, 4, summarize, emit)
@@ -746,7 +786,10 @@ export async function runTurn ({ provider, model, apiKey, getAccessToken, getAcc
       apiKey,
       accessToken,
       model,
-      system,
+      systemStable: system.stable,
+      systemVolatile: system.volatile,
+      cachingEnabled,
+      cacheTtl,
       tools: toolsEnabled,
       toolDefs,
       extraHeaders: provider.id === 'copilot' ? COPILOT_HEADERS : undefined,
@@ -761,8 +804,8 @@ export async function runTurn ({ provider, model, apiKey, getAccessToken, getAcc
       result = provider.type === 'anthropic'
         ? await anthropicRound({ ...args, messages: toAnthropic(reqMsgs) })
         : useChatgpt
-          ? await chatgptRound({ ...args, accountId, messages: reqMsgs })
-          : await openaiRound({ ...args, messages: toOpenAI(reqMsgs, system) })
+          ? await chatgptRound({ ...args, system: system.full, accountId, messages: reqMsgs })
+          : await openaiRound({ ...args, messages: toOpenAI(reqMsgs, system.full) })
       stats.llmMs += Date.now() - roundStart
     } catch (e) {
       // Model doesn't support tools (common with local models) -> retry once without them.

--- a/server/providers.js
+++ b/server/providers.js
@@ -285,9 +285,13 @@ async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, 
   // Subscription (OAuth) requests must present as Claude Code: the first system
   // block is the CLI's identity, auth is Bearer, and the oauth beta is set.
   const CLAUDE_CODE_ID = "You are Claude Code, Anthropic's official CLI for Claude."
+  // Prompt caching: mark the last system block cacheable. Anthropic renders
+  // tools -> system -> messages, so a breakpoint on the last system block caches
+  // the tool definitions too — no separate marker needed on `tools`. System must
+  // be block form (not a bare string) for cache_control to attach.
   const sys = accessToken
-    ? [{ type: 'text', text: CLAUDE_CODE_ID }, { type: 'text', text: system }]
-    : system
+    ? [{ type: 'text', text: CLAUDE_CODE_ID }, { type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
+    : [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
   const body = { model, max_tokens: 8192, system: sys, messages, stream: true }
   // ⚠️ RAISE max_tokens WITH THE BUDGET, do not carve the budget out of it — the
   // thinking budget and the visible reply share this number, so a 12k budget under
@@ -298,6 +302,21 @@ async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, 
     body.max_tokens = 8192 + THINK_BUDGET[effort]
   }
   if (tools) body.tools = (toolDefs || TOOL_DEFS).map(t => ({ name: t.name, description: t.description, input_schema: t.input_schema }))
+  // Second cache breakpoint on the tail of the growing conversation: each new
+  // turn reuses everything before this message from cache, and the marker walks
+  // forward as history grows (Anthropic's documented multi-turn placement
+  // pattern). Non-mutating — toAnthropic() builds fresh objects per call.
+  if (messages.length) {
+    const lastMsg = messages[messages.length - 1]
+    if (Array.isArray(lastMsg.content) && lastMsg.content.length) {
+      const i = lastMsg.content.length - 1
+      messages = [
+        ...messages.slice(0, -1),
+        { ...lastMsg, content: [...lastMsg.content.slice(0, i), { ...lastMsg.content[i], cache_control: { type: 'ephemeral' } }] }
+      ]
+      body.messages = messages
+    }
+  }
   const headers = { 'content-type': 'application/json', 'anthropic-version': '2023-06-01' }
   if (accessToken) {
     headers.authorization = `Bearer ${accessToken}`
@@ -317,7 +336,14 @@ async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, 
   let current = null // {type:'text',text} or {type:'tool',id,name,json}
   let stopReason = null
   for await (const ev of sseEvents(res)) {
-    if (ev.type === 'message_start' && ev.message?.usage) emit({ type: 'usage', input: ev.message.usage.input_tokens, output: 0 })
+    if (ev.type === 'message_start' && ev.message?.usage) {
+      // With caching on, `input_tokens` is only the uncached remainder — cached
+      // reads/writes land in separate fields. Sum all three so the context-window
+      // gauge still reflects the true prompt size, not just what was billed fresh.
+      const u = ev.message.usage
+      const totalIn = (u.input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0)
+      emit({ type: 'usage', input: totalIn, output: 0 })
+    }
     else if (ev.type === 'content_block_start') {
       const b = ev.content_block
       if (b.type === 'text') current = { type: 'text', text: '' }

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1593,6 +1593,24 @@ function AgentPane ({ config, onSettings }) {
         />
         <span>Suggest skills from your activity <span className='desc'>— when the agent notices a repeatable, multi-step process or a workflow you set, it drafts a skill and asks you to approve it in Settings → Skills (cloud models only)</span></span>
       </label>
+      <label className='check-row'>
+        <input
+          type='checkbox'
+          checked={s.promptCaching !== false}
+          onChange={e => onSettings({ promptCaching: e.target.checked })}
+        />
+        <span>Prompt caching (Claude models) <span className='desc'>— reuse the unchanged part of the system prompt across turns instead of resending it in full. Turn off if a custom Anthropic-compatible endpoint rejects it.</span></span>
+      </label>
+      {s.promptCaching !== false && (
+        <div style={{ marginLeft: 24, marginTop: -4, marginBottom: 4 }}>
+          <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 6 }}>Cache lifetime — match it to how quickly you usually reply</div>
+          <div className='seg-control'>
+            {[['5m', '5 minutes (default)'], ['1h', '1 hour (costs more per write, survives longer gaps)']].map(([id, label]) => (
+              <button key={id} className={'seg-btn' + ((s.cacheTtl === '1h' ? '1h' : '5m') === id ? ' on' : '')} onClick={() => onSettings({ cacheTtl: id })}>{label}</button>
+            ))}
+          </div>
+        </div>
+      )}
       <div style={{ marginTop: 10 }}>
         <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 6 }}>Default workspace folder for new sessions</div>
         <input


### PR DESCRIPTION
## Summary

**Update (this revision):** the original version of this PR (converted to draft 2026-09-05 after an independent audit — see the PR comment) put its cache breakpoint on a system prefix that included memory facts and, when an agent has a plannerModel, a freshly-generated plan addendum — both recomputed from the CURRENT turn's input, so they differ almost every turn. Net effect on memory-enabled sessions: a 1.25x cache-write cost every turn with ~zero read benefit, worse than shipping no caching at all. This revision fixes that, adds a caching on/off setting and a TTL setting, replaces the previous single moving message-tail marker with Anthropic's actual documented default for multi-turn conversations, and is now live-verified against both the OAuth (subscription) and API-key paths.

- `systemPrompt()` (`server/providers.js`) now returns `{stable, volatile}`. **Stable** = identity, tool-use instructions, persona, skills, cwd, planMode/computerControl/useTools — everything that only changes when the user explicitly reconfigures the session. **Volatile** = retrieved memory facts (`relevantFacts()` is scored against this turn's text — see `server/memory.js`) and the per-turn lead-model plan addendum (now threaded through as a separate `planAddendum` param instead of being folded into `persona`). The `cache_control` marker goes on the last block of the stable half only; the volatile half is a separate, unmarked system block appended after it — still sent every turn, but its churn can't invalidate the marked prefix ahead of it.
- Added a **top-level automatic `cache_control`** on the request for the growing message tail — this is Anthropic's documented default placement for multi-turn conversations (walks its own breakpoint forward, avoids hand-tracking the 20-block lookback window), and composes with the explicit system-block marker (2 of the 4 available breakpoint slots used). This replaces the previous single moving message-tail marker.
- **Correction:** the original commit called the single moving message marker "Anthropic's documented multi-turn placement pattern." It wasn't — top-level automatic caching (used here now) is.
- **New setting:** Settings → Agent → "Prompt caching (Claude models)", on by default, off for Anthropic-compatible `baseUrl`s that reject `cache_control` or for single-shot turns that get no read benefit from a write.
- **New setting:** cache TTL — 5-minute (default) or 1-hour (needs the `extended-cache-ttl-2025-04-11` beta header). Left as a user choice rather than hardcoded, since the right value depends on how quickly the user actually replies.
- Caching is skipped when the stable prefix (system text + tool definitions, since tools render before system and share the cached prefix) estimates under ~1024 tokens — shorter prefixes silently don't cache anyway, so a marker there is a pure write-cost with no possible read.
- `ContextGauge`'s usage fix from the original PR is unchanged: `message_start` sums `input_tokens + cache_creation_input_tokens + cache_read_input_tokens` so the context meter doesn't under-report once caching is active.

## Test plan (this revision)

- [x] `node --check server/providers.js` / `server/index.js`
- [x] `npx vite build` — clean, `Settings.jsx`'s new UI compiles
- [x] `npm run test:api` — 25/25 existing regression checks pass
- [x] **Live test, OAuth (subscription) path** — Radiant's daily-driver auth. Threw away a `HOME`/data dir (`scripts/test-api.mjs`'s pattern), copied only the `oauth.anthropic` fields out of a real Radiant install (never touched the live `~/.radiant`), ran a real 2-turn memory-enabled session against `api.anthropic.com` with a *different* question and *different* scored memory facts each turn (proving the volatile split, not just "it caches something"):
  - Turn 1: `cache_creation_input_tokens: 3187`
  - Turn 2: `cache_read_input_tokens: 3187` — full hit on the stable prefix despite the differing memory/question content
  - Confirmed the caching-off setting actually disables it: same session shape with the setting off showed `cache_creation_input_tokens: 0` / `cache_read_input_tokens: 0` on every round, full-price `input_tokens` throughout.
- [x] **Live test, API-key path** — same throwaway-`HOME` pattern with a disposable test key, same 2-turn memory-enabled shape:
  - Turn 1: `cache_creation_input_tokens: 3175`
  - Turn 2: `cache_read_input_tokens: 3175` — full hit, matching the OAuth result
  - Off-toggle re-confirmed on this path too: `cache_creation_input_tokens: 0` / `cache_read_input_tokens: 0` on both turns with caching off.
- [x] Non-Anthropic `baseUrl` path (`openaiRound`) — unaffected by inspection (never receives `systemStable`/`systemVolatile`/`cachingEnabled`, only the concatenated `system.full` string) and structurally identical regardless of which Anthropic auth path is in use.

Both credential paths are now live-verified. Happy to adjust the ~1024-token cacheability threshold if anyone wants a different margin.
