### PR TITLE
Extend caching to OpenAI-family provider paths

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2396,7 +2396,16 @@ app.post('/api/chat', async (req, res) => {
 
   // lead/worker: if this agent has a planner model, have the (stronger) lead model
   // outline the approach first; the (session) model then executes it.
-  let plannedPersona = agent?.persona || ''
+  //
+  // ⚠️ THE PLAN TEXT IS PER-TURN, THE PERSONA ISN'T. `plan` is regenerated fresh
+  // from `text` (this turn's request) every time this branch runs, so it must
+  // travel to providers.js as `planAddendum` (the volatile half of the system
+  // prompt), not folded into `persona` (the stable half) — see providers.js's
+  // systemPrompt() comment. Folding it into persona was the original prompt-
+  // caching bug: it made the "stable" system block change on every turn a
+  // plannerModel was configured.
+  const basePersona = agent?.persona || ''
+  let planAddendum = ''
   if (agent?.plannerModel && agent?.plannerProvider && session.useTools !== false && !session.group) {
     const pProvider = config.providers.find(p => p.id === agent.plannerProvider)
     if (pProvider) {
@@ -2414,7 +2423,7 @@ app.post('/api/chat', async (req, res) => {
           requestApproval: null, signal: controller.signal
         })
       } catch {}
-      if (plan.trim()) plannedPersona = `${plannedPersona}\n\n[A lead model has planned the approach below — follow it, adapting as needed:]\n${plan.trim()}`
+      if (plan.trim()) planAddendum = `[A lead model has planned the approach below — follow it, adapting as needed:]\n${plan.trim()}`
     }
   }
 
@@ -2429,6 +2438,8 @@ app.post('/api/chat', async (req, res) => {
     summarize,
     autoCompact: config.settings.autoCompact !== false,
     autoApproveComputer: config.settings.fullAutomation === true,
+    cachingEnabled: config.settings.promptCaching !== false,
+    cacheTtl: config.settings.cacheTtl === '1h' ? '1h' : '5m',
     mcpTools,
     callMcp,
     emit,
@@ -2456,7 +2467,8 @@ app.post('/api/chat', async (req, res) => {
         ...common,
         useTools: session.useTools !== false,
         computerControl: Boolean(session.computerControl),
-        persona: plannedPersona,
+        persona: basePersona,
+        planAddendum,
         skills: mergedSkills,
         askAgent,
         peerAgents,

--- a/server/providers.js
+++ b/server/providers.js
@@ -217,9 +217,13 @@ async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, 
   // Subscription (OAuth) requests must present as Claude Code: the first system
   // block is the CLI's identity, auth is Bearer, and the oauth beta is set.
   const CLAUDE_CODE_ID = "You are Claude Code, Anthropic's official CLI for Claude."
+  // Prompt caching: mark the last system block cacheable. Anthropic renders
+  // tools -> system -> messages, so a breakpoint on the last system block caches
+  // the tool definitions too — no separate marker needed on `tools`. System must
+  // be block form (not a bare string) for cache_control to attach.
   const sys = accessToken
-    ? [{ type: 'text', text: CLAUDE_CODE_ID }, { type: 'text', text: system }]
-    : system
+    ? [{ type: 'text', text: CLAUDE_CODE_ID }, { type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
+    : [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
   const body = { model, max_tokens: 8192, system: sys, messages, stream: true }
   // ⚠️ RAISE max_tokens WITH THE BUDGET, do not carve the budget out of it — the
   // thinking budget and the visible reply share this number, so a 12k budget under
@@ -230,6 +234,21 @@ async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, 
     body.max_tokens = 8192 + THINK_BUDGET[effort]
   }
   if (tools) body.tools = (toolDefs || TOOL_DEFS).map(t => ({ name: t.name, description: t.description, input_schema: t.input_schema }))
+  // Second cache breakpoint on the tail of the growing conversation: each new
+  // turn reuses everything before this message from cache, and the marker walks
+  // forward as history grows (Anthropic's documented multi-turn placement
+  // pattern). Non-mutating — toAnthropic() builds fresh objects per call.
+  if (messages.length) {
+    const lastMsg = messages[messages.length - 1]
+    if (Array.isArray(lastMsg.content) && lastMsg.content.length) {
+      const i = lastMsg.content.length - 1
+      messages = [
+        ...messages.slice(0, -1),
+        { ...lastMsg, content: [...lastMsg.content.slice(0, i), { ...lastMsg.content[i], cache_control: { type: 'ephemeral' } }] }
+      ]
+      body.messages = messages
+    }
+  }
   const headers = { 'content-type': 'application/json', 'anthropic-version': '2023-06-01' }
   if (accessToken) {
     headers.authorization = `Bearer ${accessToken}`
@@ -249,7 +268,14 @@ async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, 
   let current = null // {type:'text',text} or {type:'tool',id,name,json}
   let stopReason = null
   for await (const ev of sseEvents(res)) {
-    if (ev.type === 'message_start' && ev.message?.usage) emit({ type: 'usage', input: ev.message.usage.input_tokens, output: 0 })
+    if (ev.type === 'message_start' && ev.message?.usage) {
+      // With caching on, `input_tokens` is only the uncached remainder — cached
+      // reads/writes land in separate fields. Sum all three so the context-window
+      // gauge still reflects the true prompt size, not just what was billed fresh.
+      const u = ev.message.usage
+      const totalIn = (u.input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0)
+      emit({ type: 'usage', input: totalIn, output: 0 })
+    }
     else if (ev.type === 'content_block_start') {
       const b = ev.content_block
       if (b.type === 'text') current = { type: 'text', text: '' }

--- a/server/providers.js
+++ b/server/providers.js
@@ -9,23 +9,52 @@ import { COPILOT_HEADERS } from './oauth.js'
 
 const MAX_ROUNDS = 30
 
-function systemPrompt (cwd, useTools, model, computerControl, skills, persona, planMode, memory) {
+// Split into a STABLE half (identical across turns unless the user explicitly
+// reconfigures the session — persona, skills, cwd, tool/plan/computer-control
+// toggles) and a VOLATILE half (recomputed fresh from the CURRENT turn's input,
+// so it is essentially guaranteed to differ every request): retrieved memory
+// facts (relevantFacts() is scored against this turn's user text — see
+// server/memory.js) and the lead-model plan addendum (regenerated per turn when
+// an agent has a plannerModel). Putting volatile content in the system array
+// AFTER a cache_control-marked stable block keeps the marked prefix byte-
+// identical across turns without touching the volatile content's visibility —
+// see the claude-api skill's shared/prompt-caching.md, "Architectural guidance"
+// + "Multi-turn conversations". A stable-half change (e.g. the user flips
+// planMode or edits skills) is a one-time cache miss, not a per-turn one — that
+// tradeoff is deliberate, not the bug this split fixes.
+function systemPrompt (cwd, useTools, model, computerControl, skills, persona, planMode, planAddendum, memory) {
   const personaText = persona ? `\n\n${persona}` : ''
-  const memoryText = (memory && memory.length)
-    ? `\n\nWhat you remember about this user and their projects (from past sessions — use it when relevant, don't recite it):\n${memory.map(f => `• ${f}`).join('\n')}`
-    : ''
   const planText = planMode
     ? '\n\nPLAN MODE IS ON. Do NOT edit files, create files, or run mutating commands yet. Research the codebase (read/list/grep only), think through the approach, then present a concrete step-by-step plan by calling the exit_plan_mode tool with your plan in markdown. Only after the user approves the plan will you be able to make changes.'
     : ''
   const skillText = (skills && skills.length)
     ? `\n\nActive skills (follow these):\n${skills.map(s => `• ${s.name}: ${s.content}${s.dir && resolveSkillDir(s.dir) ? `\n  Skill folder: ${resolveSkillDir(s.dir)}` : ''}`).join('\n')}`
     : ''
-  return `You are a coding agent running inside Radiant, a local coding harness on the user's ${os.type() === 'Darwin' ? 'Mac' : os.type()} (${os.platform()} ${os.release()}). Radiant is the app, not you: you are the model "${model}". If asked what model you are, answer with your actual model name and maker.${personaText}
+  const stable = `You are a coding agent running inside Radiant, a local coding harness on the user's ${os.type() === 'Darwin' ? 'Mac' : os.type()} (${os.platform()} ${os.release()}). Radiant is the app, not you: you are the model "${model}". If asked what model you are, answer with your actual model name and maker.${personaText}
 Workspace directory: ${cwd}
 ${useTools ? 'You have tools to read, write, and edit files and to run shell commands in the workspace. Use them to investigate before answering and to make changes when asked. Prefer edit_file for small changes and write_file for new files. After making changes, verify them when practical (run the code, run tests).' : 'Tools are disabled for this conversation; answer from knowledge and the conversation only.'}${computerControl ? `
 You can also control the computer. browser_* tools drive an automated browser; screen_* tools control the whole desktop. ALWAYS take a screenshot first (browser_screenshot / screen_screenshot) and look at it before clicking or typing — click coordinates are pixel positions read from the most recent screenshot. Work in small steps: screenshot, act, screenshot again to confirm. Prefer browser_* for web tasks.` : ''}
-Be direct and concise. Use markdown; fence code blocks with a language tag. When you finish a task, summarize what changed in a sentence or two.${planText}${skillText}${memoryText}`
+Be direct and concise. Use markdown; fence code blocks with a language tag. When you finish a task, summarize what changed in a sentence or two.${planText}${skillText}`
+
+  const planAddendumText = planAddendum ? `\n\n${planAddendum}` : ''
+  const memoryText = (memory && memory.length)
+    ? `\n\nWhat you remember about this user and their projects (from past sessions — use it when relevant, don't recite it):\n${memory.map(f => `• ${f}`).join('\n')}`
+    : ''
+  const volatile = `${planAddendumText}${memoryText}`
+
+  return { stable, volatile, full: stable + volatile }
 }
+
+// Very rough token estimate (chars/4) used only to decide whether the stable
+// system prefix clears a model's minimum cacheable length — see
+// shared/prompt-caching.md's per-model minimum table (512-4096 tokens,
+// non-monotonic across generations). Radiant supports arbitrary/rolling model
+// ids across many Anthropic-compatible endpoints, so there's no reliable way to
+// look up an exact per-model number here; 1024 is a conservative mid-table
+// default that a real coding-agent system prompt (identity + tool
+// instructions + persona/skills) almost always clears anyway.
+const MIN_CACHEABLE_TOKENS = 1024
+function roughTokens (text) { return Math.round((text || '').length / 4) }
 
 // ---------- internal message format -> provider wire formats ----------
 // session.messages: [{role:'user', text, attachments} | {role:'assistant', parts:[{type:'text',text}|{type:'tool',id,name,args,result}]}]
@@ -213,17 +242,34 @@ export const EFFORTS = ['auto', 'low', 'medium', 'high']
 // its own, so max_tokens is raised alongside rather than eaten into.
 const THINK_BUDGET = { low: 2048, medium: 6144, high: 12288 }
 
-async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, system, tools, toolDefs, effort, emit, signal }) {
+async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, systemStable, systemVolatile, tools, toolDefs, effort, cachingEnabled, cacheTtl, emit, signal }) {
   // Subscription (OAuth) requests must present as Claude Code: the first system
   // block is the CLI's identity, auth is Bearer, and the oauth beta is set.
   const CLAUDE_CODE_ID = "You are Claude Code, Anthropic's official CLI for Claude."
-  // Prompt caching: mark the last system block cacheable. Anthropic renders
-  // tools -> system -> messages, so a breakpoint on the last system block caches
-  // the tool definitions too — no separate marker needed on `tools`. System must
-  // be block form (not a bare string) for cache_control to attach.
-  const sys = accessToken
-    ? [{ type: 'text', text: CLAUDE_CODE_ID }, { type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
-    : [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
+  // Prompt caching, on by default (Settings → caching toggle) but skippable —
+  // some Anthropic-compatible baseUrls reject cache_control, and single-shot
+  // (non-conversational) turns get zero benefit from a cache write.
+  // ⚠️ ONLY THE STABLE HALF GETS THE MARKER. Anthropic renders tools -> system
+  // -> messages, so a breakpoint on the last block of the stable system text
+  // caches tool definitions too. The volatile half (memory / plan addendum —
+  // see systemPrompt()'s comment) is appended as a SEPARATE, unmarked system
+  // block after it: still sent every turn, but its churn can't invalidate the
+  // marked prefix before it. System must be block form (not a bare string) for
+  // cache_control to attach.
+  // Anthropic renders tools BEFORE system, and a breakpoint on the last system
+  // block caches both together — so the minimum-cacheable-length check has to
+  // count tool definitions too, not just the (often short on its own) stable
+  // system text. Measuring systemStable alone under-counts the real prefix and
+  // wrongly skips caching on a normal tool-using turn.
+  const toolDefsForBody = tools ? (toolDefs || TOOL_DEFS).map(t => ({ name: t.name, description: t.description, input_schema: t.input_schema })) : null
+  const prefixTokens = roughTokens(systemStable) + (toolDefsForBody ? roughTokens(JSON.stringify(toolDefsForBody)) : 0)
+  const useCaching = cachingEnabled !== false && prefixTokens >= MIN_CACHEABLE_TOKENS
+  const cacheControl = useCaching ? { type: 'ephemeral', ...(cacheTtl === '1h' ? { ttl: '1h' } : {}) } : null
+  const sys = accessToken ? [{ type: 'text', text: CLAUDE_CODE_ID }] : []
+  sys.push(cacheControl
+    ? { type: 'text', text: systemStable, cache_control: cacheControl }
+    : { type: 'text', text: systemStable })
+  if (systemVolatile) sys.push({ type: 'text', text: systemVolatile })
   const body = { model, max_tokens: 8192, system: sys, messages, stream: true }
   // ⚠️ RAISE max_tokens WITH THE BUDGET, do not carve the budget out of it — the
   // thinking budget and the visible reply share this number, so a 12k budget under
@@ -233,28 +279,22 @@ async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, 
     body.thinking = { type: 'enabled', budget_tokens: THINK_BUDGET[effort] }
     body.max_tokens = 8192 + THINK_BUDGET[effort]
   }
-  if (tools) body.tools = (toolDefs || TOOL_DEFS).map(t => ({ name: t.name, description: t.description, input_schema: t.input_schema }))
-  // Second cache breakpoint on the tail of the growing conversation: each new
-  // turn reuses everything before this message from cache, and the marker walks
-  // forward as history grows (Anthropic's documented multi-turn placement
-  // pattern). Non-mutating — toAnthropic() builds fresh objects per call.
-  if (messages.length) {
-    const lastMsg = messages[messages.length - 1]
-    if (Array.isArray(lastMsg.content) && lastMsg.content.length) {
-      const i = lastMsg.content.length - 1
-      messages = [
-        ...messages.slice(0, -1),
-        { ...lastMsg, content: [...lastMsg.content.slice(0, i), { ...lastMsg.content[i], cache_control: { type: 'ephemeral' } }] }
-      ]
-      body.messages = messages
-    }
-  }
+  if (toolDefsForBody) body.tools = toolDefsForBody
+  // Top-level automatic caching covers the growing conversation tail: Anthropic
+  // places (and walks forward) its own breakpoint on the last cacheable message
+  // block, which is the documented default for multi-turn conversations and
+  // avoids hand-tracking positions against the 20-block lookback window
+  // ourselves (shared/prompt-caching.md, "Automatic vs explicit breakpoints" +
+  // "The robust combination for agent loops"). Composes with the explicit
+  // system-block marker above (2 of the 4 available breakpoint slots used).
+  if (useCaching && messages.length) body.cache_control = cacheControl
   const headers = { 'content-type': 'application/json', 'anthropic-version': '2023-06-01' }
   if (accessToken) {
     headers.authorization = `Bearer ${accessToken}`
-    headers['anthropic-beta'] = 'oauth-2025-04-20,claude-code-20250219'
+    headers['anthropic-beta'] = ['oauth-2025-04-20', 'claude-code-20250219', ...(cacheTtl === '1h' ? ['extended-cache-ttl-2025-04-11'] : [])].join(',')
   } else {
     headers['x-api-key'] = apiKey
+    if (cacheTtl === '1h') headers['anthropic-beta'] = 'extended-cache-ttl-2025-04-11'
   }
   const res = await fetch(`${baseUrl}/v1/messages`, {
     method: 'POST',
@@ -555,9 +595,9 @@ async function compactSession (session, keepRecent, summarize, emit) {
 }
 
 // ---------- the agent loop ----------
-export async function runTurn ({ provider, model, apiKey, getAccessToken, getAccountId, session, useTools, computerControl, skills, persona, memory, agentId, groupSpeakerId, groupNames, mcpTools, callMcp, askAgent, peerAgents, planMode, onPlanExit, effort, summarize, autoCompact, autoApproveComputer, emit, requestApproval, requestUserChoice, signal }) {
+export async function runTurn ({ provider, model, apiKey, getAccessToken, getAccountId, session, useTools, computerControl, skills, persona, planAddendum, memory, agentId, groupSpeakerId, groupNames, mcpTools, callMcp, askAgent, peerAgents, planMode, onPlanExit, effort, summarize, autoCompact, autoApproveComputer, cachingEnabled, cacheTtl, emit, requestApproval, requestUserChoice, signal }) {
   const cwd = session.cwd || os.homedir()
-  const system = systemPrompt(cwd, useTools, model, computerControl, skills, persona, planMode, memory)
+  const system = systemPrompt(cwd, useTools, model, computerControl, skills, persona, planMode, planAddendum, memory)
   // proactive compaction before a very long turn
   if (autoCompact && summarize && estimateTokens(session.messages) > PROACTIVE_TOKENS) {
     await compactSession(session, 4, summarize, emit)
@@ -624,7 +664,10 @@ export async function runTurn ({ provider, model, apiKey, getAccessToken, getAcc
       apiKey,
       accessToken,
       model,
-      system,
+      systemStable: system.stable,
+      systemVolatile: system.volatile,
+      cachingEnabled,
+      cacheTtl,
       tools: toolsEnabled,
       toolDefs,
       extraHeaders: provider.id === 'copilot' ? COPILOT_HEADERS : undefined,
@@ -639,8 +682,8 @@ export async function runTurn ({ provider, model, apiKey, getAccessToken, getAcc
       result = provider.type === 'anthropic'
         ? await anthropicRound({ ...args, messages: toAnthropic(reqMsgs) })
         : useChatgpt
-          ? await chatgptRound({ ...args, accountId, messages: reqMsgs })
-          : await openaiRound({ ...args, messages: toOpenAI(reqMsgs, system) })
+          ? await chatgptRound({ ...args, system: system.full, accountId, messages: reqMsgs })
+          : await openaiRound({ ...args, messages: toOpenAI(reqMsgs, system.full) })
       stats.llmMs += Date.now() - roundStart
     } catch (e) {
       // Model doesn't support tools (common with local models) -> retry once without them.

--- a/server/providers.js
+++ b/server/providers.js
@@ -345,12 +345,34 @@ async function anthropicRound ({ baseUrl, apiKey, accessToken, model, messages, 
   return { parts, stopOnTools: stopReason === 'tool_use' }
 }
 
-async function openaiRound ({ baseUrl, apiKey, accessToken, model, messages, tools, toolDefs, extraHeaders, effort, emit, signal }) {
+// OpenRouter passes Anthropic-style cache_control breakpoints through to Claude
+// models routed via Anthropic on its /chat/completions endpoint (confirmed against
+// OpenRouter's current docs, "Explicit per-block cache_control breakpoints work
+// across all Anthropic-compatible providers"). Mirrors PR #3's two-breakpoint
+// pattern: mark the system prefix and the tail message. OpenAI itself and every
+// other openaiRound-routed provider (plain OpenAI, Ollama, LM Studio, Copilot,
+// xAI, etc.) get NO markers here — OpenAI's own caching is automatic/implicit and
+// needs no client marker (see openaiRound's usage-observability comment below),
+// and other providers may reject an unrecognized `cache_control` field outright.
+function withOpenRouterClaudeCaching (body, provider, model) {
+  if (provider?.id !== 'openrouter' || !/claude/i.test(model || '')) return
+  const ephemeral = { type: 'ephemeral' }
+  const asBlock = content => typeof content === 'string'
+    ? [{ type: 'text', text: content, cache_control: ephemeral }]
+    : content
+  const sys = body.messages.find(m => m.role === 'system')
+  if (sys) sys.content = asBlock(sys.content)
+  const last = body.messages[body.messages.length - 1]
+  if (last && last !== sys && typeof last.content === 'string') last.content = asBlock(last.content)
+}
+
+async function openaiRound ({ baseUrl, apiKey, accessToken, model, messages, tools, toolDefs, extraHeaders, effort, provider, emit, signal }) {
   const body = { model, messages, stream: true }
   if (effort && effort !== 'auto') body.reasoning_effort = effort
   if (tools) {
     body.tools = (toolDefs || TOOL_DEFS).map(t => ({ type: 'function', function: { name: t.name, description: t.description, parameters: t.input_schema } }))
   }
+  withOpenRouterClaudeCaching(body, provider, model)
   const headers = { 'content-type': 'application/json', ...(extraHeaders || {}) }
   const bearer = accessToken || apiKey
   if (bearer) headers.authorization = `Bearer ${bearer}`
@@ -362,7 +384,17 @@ async function openaiRound ({ baseUrl, apiKey, accessToken, model, messages, too
   let finish = null
   for await (const chunk of sseEvents(res)) {
     const choice = chunk.choices?.[0]
-    if (chunk.usage) emit({ type: 'usage', input: chunk.usage.prompt_tokens, output: chunk.usage.completion_tokens })
+    if (chunk.usage) {
+      // Unlike Anthropic, OpenAI-family cached_tokens is a SUBSET of prompt_tokens,
+      // not additive — prompt_tokens already reflects the true prefix size, so
+      // there is no under-reporting bug here for the ContextGauge to fix (that was
+      // Anthropic-specific, see anthropicRound). cacheRead is surfaced separately,
+      // purely for a future cache-hit-rate indicator, and is a no-op if the
+      // provider doesn't send prompt_tokens_details (most non-OpenAI/OpenRouter
+      // openaiRound providers won't).
+      const cacheRead = chunk.usage.prompt_tokens_details?.cached_tokens
+      emit({ type: 'usage', input: chunk.usage.prompt_tokens, output: chunk.usage.completion_tokens, ...(cacheRead ? { cacheRead } : {}) })
+    }
     if (!choice) continue
     const d = choice.delta || {}
     const reasoning = d.reasoning_content ?? d.reasoning
@@ -664,6 +696,7 @@ export async function runTurn ({ provider, model, apiKey, getAccessToken, getAcc
       apiKey,
       accessToken,
       model,
+      provider,
       systemStable: system.stable,
       systemVolatile: system.volatile,
       cachingEnabled,

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1593,6 +1593,24 @@ function AgentPane ({ config, onSettings }) {
         />
         <span>Suggest skills from your activity <span className='desc'>— when the agent notices a repeatable, multi-step process or a workflow you set, it drafts a skill and asks you to approve it in Settings → Skills (cloud models only)</span></span>
       </label>
+      <label className='check-row'>
+        <input
+          type='checkbox'
+          checked={s.promptCaching !== false}
+          onChange={e => onSettings({ promptCaching: e.target.checked })}
+        />
+        <span>Prompt caching (Claude models) <span className='desc'>— reuse the unchanged part of the system prompt across turns instead of resending it in full. Turn off if a custom Anthropic-compatible endpoint rejects it.</span></span>
+      </label>
+      {s.promptCaching !== false && (
+        <div style={{ marginLeft: 24, marginTop: -4, marginBottom: 4 }}>
+          <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 6 }}>Cache lifetime — match it to how quickly you usually reply</div>
+          <div className='seg-control'>
+            {[['5m', '5 minutes (default)'], ['1h', '1 hour (costs more per write, survives longer gaps)']].map(([id, label]) => (
+              <button key={id} className={'seg-btn' + ((s.cacheTtl === '1h' ? '1h' : '5m') === id ? ' on' : '')} onClick={() => onSettings({ cacheTtl: id })}>{label}</button>
+            ))}
+          </div>
+        </div>
+      )}
       <div style={{ marginTop: 10 }}>
         <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 6 }}>Default workspace folder for new sessions</div>
         <input


### PR DESCRIPTION
## Summary

Follow-up to #3 (Anthropic path). Investigated the three remaining OpenAI-family surfaces: plain OpenAI API traffic, the unofficial ChatGPT-subscription path, and OpenRouter-proxied Claude models.

- **OpenRouter → Claude models (implemented).** These route through `openaiRound`, not `anthropicRound`, so #3 didn't cover them. OpenRouter's current docs confirm explicit `cache_control` breakpoints pass through to Claude models on their `/chat/completions` endpoint. Added `withOpenRouterClaudeCaching()`: applies the same system-prefix + tail-message two-breakpoint pattern as #3, scoped strictly to `provider.id === 'openrouter'` and a model id matching `/claude/i`. No other provider is touched.

- **Plain OpenAI API traffic (unchanged, observability added).** OpenAI's own caching is automatic/implicit — no client-side marker needed (verified against current OpenAI docs, not assumed from training data). Added a `cacheRead` field to the emitted `usage` event, sourced from `usage.prompt_tokens_details.cached_tokens` when the provider sends it, for a future cache-hit-rate indicator. No fix was needed for the context gauge — OpenAI's `cached_tokens` is a subset of `prompt_tokens`, not additive on top of it like Anthropic's `cache_read_input_tokens`.

- **ChatGPT-subscription path — investigated, deliberately NOT implemented.** `chatgptRound` hits an unofficial endpoint (`chatgpt.com/backend-api/codex/responses`) with `store: false`, resending full history every turn. I checked Codex CLI's own open-source Rust client to see how *it* avoids this: it does chain `previous_response_id`, but that chaining is wired exclusively into its WebSocket session-reuse path (`stream_responses_websocket` in `codex-rs/core/src/client.rs`) — the plain-HTTP request builder it also has (`stream_responses_api`), which is the shape this code mirrors, never sets `previous_response_id` at all. I attempted a live two-turn HTTP probe to double check directly, but the available OAuth token had expired and I couldn't refresh it in this environment, so the probe itself is inconclusive — the source-code evidence is what this decision rests on. Chaining over plain HTTP would need its own investigation (or dropping down to a WebSocket implementation), which is out of scope here. Left as-is rather than shipping something unverified.

- **Left alone (as originally scoped):** Gemini (native caching API not reachable through the OpenAI-compat shim this code uses for it), Ollama/LM Studio (no server-side billing-relevant cache to control from the client), GitHub Copilot (unresearched).

## Test plan

- [x] `node --check server/providers.js`
- [x] `npm run test:api` — 25/25 passing
- [x] OpenRouter docs checked live (not from training-data memory) to confirm `cache_control` passthrough for Claude models
- [x] OpenAI docs checked live via the current caching guide to confirm automatic caching + usage field names
- [ ] **Not tested live**: the OpenRouter Claude-model caching path itself (needs a real OpenRouter key + Claude model — didn't have one on hand this session) and the ChatGPT-subscription path (blocked on an expired token, see above). Both are new/narrow enough that I'd want a real run before calling this done — flagging rather than claiming coverage I don't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NZ73hSHPNvgavvZSM1TTT