### PR TITLE
Radiant builds and installs on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "compile:helper": "swiftc -O native/RadiantControl.swift -o native/radiant-control -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist -Xlinker native/Info.plist",
     "app": "npm run build && electron .",
     "dist": "npm run build && npm run compile:helper && electron-builder --mac",
+    "dist:linux": "npm run build && electron-builder --linux",
     "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true",
     "release": "node scripts/release.mjs",
     "test:smoke": "node scripts/test-smoke.mjs",
@@ -49,10 +50,6 @@
     ],
     "extraResources": [
       {
-        "from": "native/radiant-control",
-        "to": "native/radiant-control"
-      },
-      {
         "from": "skills",
         "to": "skills"
       },
@@ -67,6 +64,12 @@
     ],
     "npmRebuild": false,
     "mac": {
+      "extraResources": [
+        {
+          "from": "native/radiant-control",
+          "to": "native/radiant-control"
+        }
+      ],
       "category": "public.app-category.developer-tools",
       "target": [
         {
@@ -87,6 +90,21 @@
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Radiant turns what you say into text in the message box. Audio is transcribed on this Mac and is never sent anywhere.",
         "NSSpeechRecognitionUsageDescription": "Radiant transcribes your dictation on this Mac, using Apple's on-device speech recognition. Nothing is sent to Apple or to any server."
+      }
+    },
+    "linux": {
+      "target": [
+        "AppImage"
+      ],
+      "category": "Development",
+      "icon": "build/icon.png",
+      "maintainer": "Templeton Technologies",
+      "synopsis": "A local coding harness",
+      "syncDesktopName": true,
+      "desktop": {
+        "entry": {
+          "StartupWMClass": "radiant"
+        }
       }
     }
   },

--- a/server/computer.js
+++ b/server/computer.js
@@ -42,7 +42,18 @@ export async function permissions () {
   }
 }
 
+/**
+ * ⚠️ A MACH-O BINARY ON A LINUX BOX STILL EXISTS, SO existsSync IS NOT ENOUGH.
+ * `extraResources` copies native/radiant-control into every packaged target,
+ * and the file being there was the whole test — so off a Mac this said the
+ * helper was present, execFile then failed with ENOEXEC, and the catch in
+ * permissions() answered `{ helper: true, screenRecording: null }`. That is the
+ * right answer for an OLD helper and the wrong one for a helper that can never
+ * run here: Settings offered desktop control on a machine that has none. Same
+ * shape as the bug the comment above records, one platform over.
+ */
 export function helperAvailable () {
+  if (process.platform !== 'darwin') return false
   try { return fs.existsSync(helperPath()) } catch { return false }
 }
 

--- a/server/config.js
+++ b/server/config.js
@@ -594,7 +594,11 @@ export function saveConfig (cfg, { forgetting = [] } = {}) {
 // macOS, and brctl is a diagnostic tool that does not belong in a shipped app.
 // Foundation's URL resource values are the supported answer, reached through
 // the native helper we already ship.
-const HELPER = [
+// ⚠️ AND ONLY ON macOS. The helper is Mach-O and everything it is asked here is
+// about iCloud, so off a Mac there is no question to put to it — but the file
+// ships in every packaged target, so existsSync alone would find one. Undefined
+// is what the callers below already treat as "cannot tell", which is the truth.
+const HELPER = process.platform !== 'darwin' ? undefined : [
   path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'native', 'radiant-control'),
   path.join(process.resourcesPath || '', 'native', 'radiant-control')
 ].find(p => { try { return fs.existsSync(p) } catch { return false } })


### PR DESCRIPTION
`npm run dist:linux` produces `release/Radiant-<version>.AppImage` and the `latest-linux.yml` the in-app updater reads. `electron-updater` picks `AppImageUpdater` on its own, so updating works the same way it does on a Mac once a Linux asset is published.

AppImage is the only target: a `.deb` served from GitHub Releases downloads and then fails at install unless the user happens to have added an apt repo, so it would detect an update it cannot apply.

**The `mac` block is untouched** — it keeps the same three `extraResources` it had, and nothing about a dmg build changes.

### Two things this had to fix rather than add

**⚠️ The Swift helper was shipping in the Linux build, and `helperAvailable()` said yes.**

`extraResources` is merged into every target, not replaced per-platform, so `native/radiant-control` — Mach-O arm64 — landed in the AppImage. `helperAvailable()` was `fs.existsSync` alone, so it returned `true`; `execFile` then failed with ENOEXEC, and the `catch` in `permissions()` answered `{ helper: true, screenRecording: null }`. That is the correct reply for an *old* helper and a lie about one that cannot run at all — Settings would have offered desktop control and dictation on a machine with neither.

This is the same shape as the bug the comment in `computer.js` already records, one platform over: a status derived from a file existing rather than from asking.

The binary now ships from `mac.extraResources`, and both `helperAvailable()` and `config.js`'s `HELPER` refuse off darwin — so a stale build or a hand-copied file cannot bring it back. `undefined` is what the `config.js` callers already treat as "cannot tell", which here is the truth.

**⚠️ `StartupWMClass` did not match the window.**

The generated entry said `Radiant`; the running window reports `WM_CLASS "radiant"`. GNOME linked neither, so the dock showed a generic icon beside a running app. Measured with `xprop` rather than assumed.

Note that electron-builder's own warning tells you to *"Set desktopName in package.json"* — but `desktopName` is not a valid key under `linux` in 26.15.3 (it is read from the package.json root, and the schema rejects it in the platform block). `syncDesktopName` plus an explicit lowercase `desktop.entry` is what actually works.

### Verified on Debian 13 / GNOME

The AppImage runs and the window carries `WM_CLASS "radiant"`; `/api/system` reports the real CPU, distro and free space; the terminal panel spawns a working login shell (node-pty builds from source on Linux and loads fine inside Electron); and `/api/computer-status` is honest:

```json
{"desktop":false,"browser":true,"helper":false,"screenRecording":false,"accessibility":false}
```

Installed via a `.desktop` entry and launched with `gtk-launch`, i.e. the path the GNOME menu takes, not just `./Radiant.AppImage`.

### Independent of #5

This touches `package.json`, `server/computer.js` and `server/config.js` and uses `process.platform` directly, so it applies to `master` on its own. #5 is the wider seam and does not overlap these lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
