### PR TITLE
Settings tells the truth about what this machine can do

### DIFF
--- a/server/computer-tools.js
+++ b/server/computer-tools.js
@@ -198,6 +198,13 @@ export async function computerStatus () {
   return {
     desktop: p.helper && p.screenRecording !== false && p.accessibility !== false,
     browser: await browserAvailable(),
+    // ⚠️ "NOT GRANTED" AND "DOES NOT EXIST HERE" ARE DIFFERENT ANSWERS, AND THE UI
+    // COULD NOT TELL THEM APART. Both arrive as `false`, so off a Mac Settings
+    // reported Screen Recording and Accessibility as permissions the user had
+    // failed to grant, and told them to add Radiant under System Settings →
+    // Privacy & Security — a pane that does not exist on the machine reading the
+    // advice. Rule 12: never render a state the user cannot act on.
+    platform: process.platform,
     ...p
   }
 }

--- a/server/dictate.js
+++ b/server/dictate.js
@@ -39,8 +39,16 @@ export function stopDictation () {
 
 export function startDictation (req, res, locale = 'en-US') {
   if (!helperAvailable()) {
+    // ⚠️ "NOT INSTALLED" IS THE WRONG REASON OFF A MAC, AND IT READS AS A REPAIRABLE
+    // ONE. Dictation is Apple's on-device speech recognition reached through the
+    // Swift helper; there is nothing to install elsewhere, so inviting the user to
+    // look for it sends them after a file that was never meant to be there.
     res.writeHead(503, { 'content-type': 'application/json' })
-    return res.end(JSON.stringify({ error: 'The Radiant helper is not installed, so dictation cannot start.' }))
+    return res.end(JSON.stringify({
+      error: process.platform === 'darwin'
+        ? 'The Radiant helper is not installed, so dictation cannot start.'
+        : 'Dictation uses macOS speech recognition, which this machine does not have. Type instead — nothing else is affected.'
+    }))
   }
   if (active) {
     res.writeHead(409, { 'content-type': 'application/json' })

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1656,7 +1656,24 @@ function AgentPane ({ config, onSettings }) {
           <span className={comp?.browser ? 'key-ok' : 'fit-badge fit-no'}>{comp?.browser ? '✓' : '—'} Browser control</span>
           <span className='desc'>drives your system Chrome. Nothing to set up.</span>
         </div>
-        {/* ⚠️ NAME THE PERMISSION THAT IS MISSING. This said "Screen Recording and
+        {/* ⚠️ OFF A MAC THERE IS NOTHING TO GRANT, SO THERE IS NOTHING TO ASK FOR.
+              Screen Recording and Accessibility are macOS permissions reached
+              through a Swift helper that only builds and only runs there. Both
+              come back false on any other platform, which read here as two
+              permissions the user had neglected — under advice to open a System
+              Settings pane their machine does not have. Say the true thing once
+              and point at the half that does work. */}
+        {comp?.platform && comp.platform !== 'darwin' ? (
+          <div className='comp-stat'>
+            <span className='fit-badge fit-no'>— Desktop control</span>
+            <span className='desc'>
+              not available on {comp.platform === 'linux' ? 'Linux' : 'this platform'} — Radiant
+              moves the mouse, types and captures the screen through a macOS helper, and there is
+              no equivalent here yet. Browser control above needs none of it and works.
+            </span>
+          </div>
+        ) : (<>
+          {/* ⚠️ NAME THE PERMISSION THAT IS MISSING. This said "Screen Recording and
               Accessibility are granted — ready to use" whenever the helper binary
               existed on disk, which it always does — so it claimed both while
               screencapture returned a wallpaper-only image and clicks went nowhere,
@@ -1691,6 +1708,7 @@ function AgentPane ({ config, onSettings }) {
               Browser control needs neither.
             </div>
           )}
+        </>)}
       </div>
 
       <div className='set-block'>


### PR DESCRIPTION
Measured on Debian 13, against an **unmodified `master`**:

```
GET /api/computer-status
{"desktop":true,"browser":true,"helper":true,
 "screenRecording":null,"accessibility":null}
```

`desktop: true` on a machine that cannot do any of it.

`helperAvailable()` is `fs.existsSync` and `native/radiant-control` is committed to the repo, so the helper reads as present. `execFile` then fails with ENOEXEC, `permissions()` answers `null` from its catch, and `p.helper && p.screenRecording !== false && p.accessibility !== false` is three trues.

The Automation pane printed the consequence: Screen Recording and Accessibility shown as permissions the user had failed to grant, under advice to *"Add Radiant under System Settings → Privacy & Security … macOS only re-reads these at launch"* — a pane that does not exist on the machine reading it. Rule 12 and rule 13 in the same block.

### The fix

"Not granted" and "does not exist here" are different answers, and both arrive as `false` — so the UI had no way to tell them apart. `computerStatus()` now reports `platform`, and off a Mac the pane says the true thing once:

> **What works on samirb3**
> ✓ **Browser control** — drives your system Chrome. Nothing to set up.
> — **Desktop control** — not available on Linux — Radiant moves the mouse, types and captures the screen through a macOS helper, and there is no equivalent here yet. Browser control above needs none of it and works.

**The macOS branch is untouched, comment and all.** It is still the only place that names *which* of the two permissions is missing, which it had to learn the hard way, and this change does not disturb it.

### Dictation had the same shape

Its 503 said *"The Radiant helper is not installed"* — which reads as a repairable state and sends the user looking for a file that was never meant to be there. It is Apple's on-device speech recognition; off a Mac there is nothing to install. The message now says that, and says what still works.

### Verified by opening the pane and reading it

Not by reading the diff. `test-drag`, `test-electron-safe`, `test-readme` and the other offline gates pass.

### Relationship to the other PRs

Independent — touches `server/computer-tools.js`, `server/dictate.js`, `src/components/Settings.jsx`.

It overlaps #6 in intent: #6 stops the Mach-O helper shipping in a Linux build and makes `helperAvailable()` refuse off darwin, which turns `desktop` back to `false`. **This PR is still needed with #6 applied** — `false` alone would render as "not granted", which is the wrong reason. And it is useful without #6, because it corrects the display even while the status is wrong.

One thing I noticed while capturing the pane and did **not** fix here, because #5 already does: the same screen shows *"✓ Browser control — drives your system Chrome"* and *"⚠ Google Chrome is not installed."* at once, from the hardcoded `/Applications/Google Chrome.app` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
