### PR TITLE
The update points at a file this machine can open

### DIFF
--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -15,6 +15,7 @@ run "read me"        node scripts/test-readme.mjs
 run "window drag"    node scripts/test-drag.mjs
 run "cross-origin"   node scripts/test-origin.mjs
 run "command risk"   node scripts/test-command-risk.mjs
+run "update asset"   node scripts/test-update-asset.mjs
 run "memory"         node scripts/test-memory.mjs
 run "plugin bridge"  node scripts/test-bridge.mjs
 run "cloud model"    node scripts/test-cloud-model.mjs

--- a/scripts/test-update-asset.mjs
+++ b/scripts/test-update-asset.mjs
@@ -1,0 +1,49 @@
+/**
+ * Does the update check point at a file this machine can actually open?
+ *
+ * ⚠️ THE MATCH USED TO BE /\.dmg$/ AND NOTHING ELSE, so anywhere but a Mac it
+ * found no asset and silently handed back the releases page — a wall of files
+ * to choose from, when the entire point of the check is that Radiant already
+ * knows which one is wanted. It degraded quietly enough that nothing ever said
+ * so out loud.
+ *
+ * The macOS answer must not move: it picks the versioned dmg, exactly the asset
+ * the old regex found, out of a real release that also contains a zip, two
+ * blockmaps, latest-mac.yml and the stable radiant.dmg.
+ */
+import { assetFor } from '../server/updater.js'
+
+let pass = 0, fail = 0
+const results = []
+const ok = (what, cond) => { cond ? pass++ : fail++; results.push(`  ${cond ? 'ok  ' : 'FAIL'} ${what}`) }
+
+// The asset list of a real release (v0.7.8), in the order GitHub returns it.
+const macRelease = [
+  { name: 'latest-mac.yml' },
+  { name: 'Radiant-0.7.8-arm64-mac.zip' },
+  { name: 'Radiant-0.7.8-arm64-mac.zip.blockmap' },
+  { name: 'Radiant-0.7.8-arm64.dmg' },
+  { name: 'Radiant-0.7.8-arm64.dmg.blockmap' },
+  { name: 'radiant.dmg' }
+]
+
+// The same release once a Linux artefact is published alongside it.
+const withLinux = [...macRelease, { name: 'latest-linux.yml' }, { name: 'Radiant-0.7.8.AppImage' }]
+
+ok('a Mac still gets the versioned dmg', assetFor(macRelease, 'darwin')?.name === 'Radiant-0.7.8-arm64.dmg')
+ok('a blockmap is never offered as the download', !/blockmap/.test(assetFor(macRelease, 'darwin')?.name || ''))
+ok('latest-mac.yml is never offered as the download', !/\.yml$/.test(assetFor(macRelease, 'darwin')?.name || ''))
+
+ok('Linux gets nothing while no Linux asset is published', assetFor(macRelease, 'linux') === null)
+ok('Linux gets the AppImage once one is', assetFor(withLinux, 'linux')?.name === 'Radiant-0.7.8.AppImage')
+ok('latest-linux.yml is never offered as the download', !/\.yml$/.test(assetFor(withLinux, 'linux')?.name || ''))
+ok('publishing a Linux asset does not change the Mac answer', assetFor(withLinux, 'darwin')?.name === 'Radiant-0.7.8-arm64.dmg')
+
+ok('a platform we ship nothing for asks for nothing', assetFor(withLinux, 'freebsd') === null)
+ok('an empty release is not a crash', assetFor([], 'darwin') === null)
+ok('a missing asset list is not a crash', assetFor(undefined, 'darwin') === null)
+ok('an asset with no name is not a crash', assetFor([{}], 'darwin') === null)
+
+console.log(results.join('\n'))
+console.log(`\n${pass}/${pass + fail} passed  ·  the update points at a file this machine can open`)
+process.exit(fail ? 1 : 0)

--- a/server/updater.js
+++ b/server/updater.js
@@ -16,6 +16,25 @@ export function isNewer (a, b) {
   return false
 }
 
+// ⚠️ THE ASSET THAT RUNS ON THIS MACHINE, NOT THE FIRST ONE IN THE LIST. This
+// matched /\.dmg$/ and nothing else, so anywhere but a Mac it found none and
+// silently handed back the releases page instead — a wall of files to choose
+// from, when the whole point of the check is that Radiant already knows which
+// one is wanted. The fallback stays for the case that is genuinely unknown: a
+// platform with no asset published yet, where a page you can read beats a link
+// that is wrong.
+const ASSET_FOR = {
+  darwin: /\.dmg$/i,
+  linux: /\.AppImage$/i,
+  win32: /\.exe$/i
+}
+
+export function assetFor (assets, platform = process.platform) {
+  const pattern = ASSET_FOR[platform]
+  if (!pattern) return null
+  return (assets || []).find(a => pattern.test(a?.name || '')) || null
+}
+
 export async function checkForUpdate (currentVersion) {
   const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
     headers: { 'user-agent': 'Radiant-Updater', accept: 'application/vnd.github+json' },
@@ -24,13 +43,13 @@ export async function checkForUpdate (currentVersion) {
   if (!res.ok) throw new Error(`GitHub ${res.status}`)
   const r = await res.json()
   const latest = String(r.tag_name || '').replace(/^v/, '')
-  const dmg = (r.assets || []).find(a => /\.dmg$/i.test(a.name))
+  const asset = assetFor(r.assets)
   return {
     current: currentVersion,
     latest,
     hasUpdate: Boolean(latest) && isNewer(currentVersion, latest),
     htmlUrl: r.html_url,
-    dmgUrl: dmg?.browser_download_url || r.html_url,
+    downloadUrl: asset?.browser_download_url || r.html_url,
     notes: r.body || '',
     publishedAt: r.published_at
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,7 +61,7 @@ function DesktopApp () {
     try { localStorage.setItem('radiant.rightOpen', rightOpen ? '1' : '0') } catch {}
   }, [rightOpen])
   const [rightTab, setRightTab] = useState('activity')
-  const [updateInfo, setUpdateInfo] = useState(null) // {latest, dmgUrl} when an update exists
+  const [updateInfo, setUpdateInfo] = useState(null) // {latest, downloadUrl} when an update exists
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [compareOpen, setCompareOpen] = useState(false)
   const [navOpen, setNavOpen] = useState(false) // mobile sidebar drawer

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1778,7 +1778,7 @@ function AboutPane ({ config, onSettings }) {
         else setStatus({ hasUpdate: r.hasUpdate, latest: r.version, current: r.current })
       } else {
         const r = await api.updateCheck()
-        setStatus({ hasUpdate: r.hasUpdate, latest: r.latest, current: r.current, dmgUrl: r.dmgUrl })
+        setStatus({ hasUpdate: r.hasUpdate, latest: r.latest, current: r.current, downloadUrl: r.downloadUrl })
       }
     } catch (e) { setStatus({ error: e.message }) }
     setChecking(false)
@@ -1787,7 +1787,7 @@ function AboutPane ({ config, onSettings }) {
   const startDownload = () => { setPhase('downloading'); setProgress(0); native.download() }
   const restart = () => native.install()
   const relaunch = () => native.relaunch()
-  const openReleasePage = () => window.open(status?.dmgUrl || 'https://github.com/templetongroup/radiant/releases/latest', '_blank', 'noopener')
+  const openReleasePage = () => window.open(status?.downloadUrl || 'https://github.com/templetongroup/radiant/releases/latest', '_blank', 'noopener')
 
   return (
     <div className='set-section'>


### PR DESCRIPTION
`checkForUpdate` matched `/\.dmg$/` and nothing else, so anywhere but a Mac it found no asset and quietly fell back to the releases page — a wall of files to choose from, when the whole point of the check is that Radiant already knows which one is wanted. It degraded silently enough that nothing ever said so.

`assetFor()` picks by platform: `.dmg` on darwin, `.AppImage` on linux, `.exe` on win32. The page fallback stays for the case that is genuinely unknown — a platform with no asset published yet, where something you can read beats a link that is wrong.

### The macOS answer does not move

Measured against the **real v0.7.8 release**, which carries a zip, two blockmaps, `latest-mac.yml`, the stable `radiant.dmg` and the versioned one:

```
darwin   -> Radiant-0.7.8-arm64.dmg      (exactly what the old regex found)
linux    -> (none yet — falls back to the page)
win32    -> (none yet — falls back to the page)
```

`scripts/test-update-asset.mjs` pins that, and pins the near misses too — a `.dmg.blockmap` and a `latest-*.yml` must never be offered as the download, and publishing a Linux asset must not change the Mac answer. 11 assertions, registered in `test-all.sh`.

### Rename

`dmgUrl` is now `downloadUrl`, in the two places that read it. The old name would be a lie on three platforms out of four, and it is the kind of lie that survives because it is only ever read.

### ⚠️ This does not publish anything

`scripts/release.mjs` is **deliberately untouched**. It notarises, uploads a stable `radiant.dmg` the website's button depends on, verifies the public download and updates the site's `version.json` — all of it from a Mac, none of it something I can exercise from here. Producing a Linux artefact needs a Linux builder, which is a decision about CI rather than a patch to that script.

This is the half that is ready when that day comes, and correct in the meantime: the moment any `.AppImage` is attached to a release, by whatever route you choose, Linux users get pointed at it instead of at a file list.

### Base

Rebased onto `2f56a38` — current `master` as of opening. Independent of #5, #6, #7 and #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
