### PR TITLE
The agent can drive a Linux desktop

### DIFF
--- a/gnome/radiant-control.cjs
+++ b/gnome/radiant-control.cjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Radiant desktop control helper for Linux — the X11 counterpart to
+ * native/RadiantControl.swift, speaking the same command language so
+ * server/computer.js does not have to care which one it is talking to.
+ *
+ * `screensize`, `move`, `click`, `doubleclick`, `rightclick`, `drag`, `scroll`,
+ * `type`, `key` and `permissions` behave exactly as the Swift helper's do. The
+ * iCloud commands (`ubiquity`, `icloud`, `fetch`) are absent on purpose: they
+ * ask Foundation about a service this platform does not have, and answering
+ * them with a guess would be worse than not answering.
+ *
+ * ⚠️ THIS IS A SCRIPT, NOT A COMPILED BINARY, AND THAT IS THE POINT. The macOS
+ * helper has to be Mach-O because CGEvent and Speech are Apple frameworks. Here
+ * the whole job is driving xdotool and ImageMagick, so a compiled artefact would
+ * buy nothing and cost a toolchain, a build step in `dist`, and one more thing
+ * that can ship for the wrong architecture — which is exactly how a Mach-O
+ * binary ended up inside a Linux AppImage.
+ *
+ * ⚠️ X11 ONLY, AND IT SAYS SO RATHER THAN FAILING QUIETLY. XTest — what xdotool
+ * uses to synthesise input — is refused by Wayland by design: no client may
+ * type into another client's window. There is no flag that fixes it, so on a
+ * Wayland session `permissions` reports false with a reason, and the app can
+ * tell the user the true thing instead of letting every click land nowhere.
+ */
+'use strict'
+const { execFileSync } = require('child_process')
+
+const args = process.argv.slice(2)
+const cmd = args[0]
+
+const run = (bin, argv, timeout = 15000) => execFileSync(bin, argv.map(String), { encoding: 'utf8', timeout }).trim()
+const has = bin => { try { execFileSync('sh', ['-c', `command -v ${bin}`], { stdio: 'ignore' }); return true } catch { return false } }
+const isWayland = () => (process.env.XDG_SESSION_TYPE || '').toLowerCase() === 'wayland' || Boolean(process.env.WAYLAND_DISPLAY)
+
+/** ImageMagick 7 renamed the tools; accept either, prefer whichever is present. */
+const captureTool = () => (has('import') ? 'import' : has('magick') ? 'magick' : null)
+// ⚠️ THERE IS DELIBERATELY NO RESIZE HERE. macOS downscales the capture with
+// `sips` because screencapture yields Retina pixels while CGEvent takes points,
+// and the two have to be made to agree. On X11 the root window we capture and
+// the space xdotool clicks in are the same pixels already, so scaling would
+// create the mismatch rather than remove it.
+
+/**
+ * ⚠️ cmd MEANS "THE COPY MODIFIER", NOT "THE SUPER KEY". A model that has been
+ * told it is driving a desktop emits "cmd+c" for copy, and mapping cmd to Super
+ * literally would send Super+C — which on GNOME does nothing, or opens the
+ * overview. Ctrl is what the user's own hands would press for the same intent,
+ * so that is the honest translation. computer-tools.js also names the local
+ * modifier in the tool description, so a model that reads it gets it right the
+ * first time and never relies on this.
+ */
+const MODIFIERS = {
+  cmd: 'ctrl', command: 'ctrl', meta: 'ctrl',
+  ctrl: 'ctrl', control: 'ctrl',
+  shift: 'shift',
+  alt: 'alt', option: 'alt', opt: 'alt',
+  super: 'super', win: 'super'
+}
+
+/** Names the Swift helper accepts, in the spelling xdotool wants. */
+const KEYS = {
+  return: 'Return', enter: 'Return', tab: 'Tab', space: 'space',
+  delete: 'BackSpace', backspace: 'BackSpace', forwarddelete: 'Delete',
+  escape: 'Escape', esc: 'Escape',
+  left: 'Left', right: 'Right', up: 'Up', down: 'Down',
+  home: 'Home', end: 'End', pageup: 'Prior', pagedown: 'Next'
+}
+
+/**
+ * ⚠️ A MODIFIER WE DO NOT KNOW IS A REFUSAL, NOT A SHRUG. This mapped the parts
+ * it recognised and dropped the rest, so "fn+left" pressed Left and "hyper+c"
+ * pressed c — the wrong keystroke, exit 0, and the model told it worked. That is
+ * the only thing in this file that can be wrong in silence, which is exactly why
+ * it must not be. Same for a spec with no key in it: "ctrl+" popped "ctrl" as
+ * the key and pressed Ctrl on its own.
+ *
+ * scripts/test-desktop-keys.mjs pins both, and the intent-preserving cmd→ctrl
+ * translation above.
+ */
+function xdotoolKey (spec) {
+  const parts = String(spec == null ? '' : spec).split('+').map(s => s.trim())
+  if (parts.length === 0 || parts.some(p => !p)) {
+    throw new Error(`"${spec}" is not a key combination Radiant can press.`)
+  }
+  const key = parts.pop()
+  const mods = parts.map(m => {
+    const mapped = MODIFIERS[m.toLowerCase()]
+    if (!mapped) throw new Error(`"${m}" is not a modifier Radiant knows how to press on this desktop.`)
+    return mapped
+  })
+  const low = key.toLowerCase()
+  const named = KEYS[low] || (/^f([1-9]|1[0-9]|2[0-4])$/.test(low) ? key.toUpperCase() : key)
+  return [...mods, named].join('+')
+}
+
+function fail (message) {
+  process.stderr.write(message + '\n')
+  process.exit(1)
+}
+
+function requireInput () {
+  if (isWayland()) fail('This is a Wayland session. X11 input synthesis (XTest) is refused there by design, so Radiant cannot drive the desktop.')
+  if (!has('xdotool')) fail('xdotool is not installed. Install it (apt install xdotool) to let Radiant drive the desktop.')
+}
+
+// ⚠️ THE KEY MAPPER IS THE ONLY PART THAT CAN BE WRONG IN SILENCE, so it is the
+// part that gets a gate. Everything else here either moves a real mouse or
+// fails loudly; a bad translation presses the wrong keys, exits 0, and reports
+// success to the model. scripts/test-desktop-keys.mjs pins it.
+module.exports = { xdotoolKey }
+if (require.main !== module) return
+
+switch (cmd) {
+  /**
+   * ⚠️ ASK THE SYSTEM, DO NOT ASSUME — the same rule the Swift helper carries.
+   * There it is TCC; here it is whether the session can be driven at all and
+   * whether the two tools exist. Reporting "ready" because a file is on disk is
+   * the bug that cost a session on macOS, and it is available to repeat here.
+   */
+  case 'permissions': {
+    const wayland = isWayland()
+    const out = {
+      screenRecording: !wayland && Boolean(captureTool()),
+      accessibility: !wayland && has('xdotool')
+    }
+    // Extra, and ignored by callers that only read the two booleans above: the
+    // reason, so the UI can say what to do instead of only that it cannot.
+    if (wayland) out.reason = 'wayland'
+    else if (!out.accessibility && !out.screenRecording) out.reason = 'missing:xdotool,imagemagick'
+    else if (!out.accessibility) out.reason = 'missing:xdotool'
+    else if (!out.screenRecording) out.reason = 'missing:imagemagick'
+    process.stdout.write(JSON.stringify(out))
+    break
+  }
+
+  /**
+   * ⚠️ THE WHOLE X SCREEN, NOT THE PRIMARY MONITOR. `xdotool getdisplaygeometry`
+   * is the obvious call and it is the wrong one. Measured on a two-monitor
+   * desktop (HDMI-0 at +0+0, DP-4 at +2560+0): it answers 2560x1440, while the
+   * root window we capture is 5120x1440 and `xdotool mousemove 4000 700` lands
+   * happily on the second screen. So the screenshot the model sees and the space
+   * its clicks are interpreted in would have disagreed by exactly one monitor —
+   * every click on the right-hand screen silently landing on the left one, and
+   * nothing anywhere reporting an error.
+   *
+   * The root window is the thing we screenshot, so its geometry is the one
+   * answer that cannot drift from the image. xdpyinfo and xrandr are asked in
+   * turn because neither is guaranteed installed; getdisplaygeometry is kept as
+   * a last resort, where being right about one monitor beats returning nothing.
+   */
+  case 'screensize': {
+    const fromXdpyinfo = () => {
+      const m = run('xdpyinfo', []).match(/dimensions:\s+(\d+)x(\d+)/)
+      return m && `${m[1]} ${m[2]}`
+    }
+    const fromXrandr = () => {
+      const m = run('xrandr', ['--query']).match(/current\s+(\d+)\s*x\s*(\d+)/)
+      return m && `${m[1]} ${m[2]}`
+    }
+    const fromXdotool = () => run('xdotool', ['getdisplaygeometry']).split(/\s+/).slice(0, 2).join(' ')
+
+    let size = null
+    for (const [bin, fn] of [['xdpyinfo', fromXdpyinfo], ['xrandr', fromXrandr], ['xdotool', fromXdotool]]) {
+      if (!has(bin)) continue
+      try { size = fn() } catch { /* try the next one */ }
+      if (size) break
+    }
+    if (!size) fail('Could not determine the screen size — none of xdpyinfo, xrandr or xdotool answered.')
+    process.stdout.write(size)
+    break
+  }
+
+  case 'screenshot': {
+    const dest = args[1]
+    if (!dest) fail('screenshot needs an output path.')
+    if (isWayland()) fail('This is a Wayland session; the screen cannot be captured this way.')
+    const tool = captureTool()
+    if (!tool) fail('ImageMagick is not installed. Install it (apt install imagemagick) to let Radiant see the screen.')
+    if (tool === 'magick') run('magick', ['import', '-window', 'root', dest])
+    else run('import', ['-window', 'root', dest])
+    break
+  }
+
+  case 'move':
+    requireInput()
+    run('xdotool', ['mousemove', args[1], args[2]])
+    break
+
+  case 'click':
+  case 'rightclick':
+  case 'doubleclick': {
+    requireInput()
+    const button = cmd === 'rightclick' ? '3' : '1'
+    const repeat = cmd === 'doubleclick' ? ['--repeat', '2', '--delay', '80'] : []
+    run('xdotool', ['mousemove', args[1], args[2], 'click', ...repeat, button])
+    break
+  }
+
+  case 'drag':
+    requireInput()
+    // Press, travel, release. --sync on the moves so the window manager sees a
+    // drag rather than a teleport, which is what a one-shot mousemove looks like.
+    run('xdotool', ['mousemove', args[1], args[2], 'mousedown', '1'])
+    run('xdotool', ['mousemove', '--sync', args[3], args[4]])
+    run('xdotool', ['mouseup', '1'])
+    break
+
+  case 'scroll': {
+    requireInput()
+    // ⚠️ NOT `Number(x) || 0`. That turned a dy of 0 — and any value that is not a
+    // number — into one scroll-wheel click DOWNWARD, because the sign test below
+    // reads 0 as "not positive". Asking to scroll by nothing must move nothing.
+    const dy = Number(args[3])
+    if (!Number.isFinite(dy) || dy === 0) break
+    // Button 4 is up, 5 is down; the Swift helper takes positive dy as up.
+    const button = dy > 0 ? '4' : '5'
+    const clicks = Math.min(50, Math.max(1, Math.round(Math.abs(dy) / 40)))
+    run('xdotool', ['mousemove', args[1], args[2], 'click', '--repeat', clicks, button])
+    break
+  }
+
+  case 'type': {
+    requireInput()
+    // ⚠️ NOT THROUGH A SHELL, AND NOT SPLIT ON SPACES. The text is whatever the
+    // model produced — quotes, backticks, newlines, a semicolon. execFile passes
+    // it as one argv entry, which is the only reason this is safe to hand a
+    // string that came out of a language model.
+    //
+    // ⚠️ AND `--` BEFORE IT, because that same model produces text beginning with
+    // a dash all the time — a diff line, a markdown bullet, a flag it is quoting.
+    // Without the terminator xdotool reads it as an option and refuses.
+    const text = args.slice(1).join(' ')
+    // ⚠️ A TIMEOUT THAT DOES NOT SCALE CUTS THE TEXT IN HALF. At --delay 12 a
+    // fixed 15s ceiling stops around 1250 characters — and the half already typed
+    // is in the user's document, where nothing can take it back. Give it the time
+    // the length actually needs, with headroom.
+    const budget = 5000 + text.length * 20
+    run('xdotool', ['type', '--clearmodifiers', '--delay', '12', '--', text], budget)
+    break
+  }
+
+  case 'key':
+    requireInput()
+    // xdotoolKey throws on something it will not guess at; that is a refusal the
+    // user should read, not a stack trace they have to interpret.
+    try {
+      run('xdotool', ['key', '--clearmodifiers', xdotoolKey(args[1])])
+    } catch (e) {
+      fail(e.message)
+    }
+    break
+
+  default:
+    fail(`usage: radiant-control <permissions|screensize|screenshot|move|click|rightclick|doubleclick|drag|scroll|type|key> ...`)
+}

--- a/package.json
+++ b/package.json
@@ -96,6 +96,12 @@
       "target": [
         "AppImage"
       ],
+      "extraResources": [
+        {
+          "from": "gnome/radiant-control.cjs",
+          "to": "gnome/radiant-control.cjs"
+        }
+      ],
       "category": "Development",
       "icon": "build/icon.png",
       "maintainer": "Templeton Technologies",

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -16,6 +16,7 @@ run "window drag"    node scripts/test-drag.mjs
 run "cross-origin"   node scripts/test-origin.mjs
 run "command risk"   node scripts/test-command-risk.mjs
 run "update asset"   node scripts/test-update-asset.mjs
+run "desktop keys"   node scripts/test-desktop-keys.mjs
 run "memory"         node scripts/test-memory.mjs
 run "plugin bridge"  node scripts/test-bridge.mjs
 run "cloud model"    node scripts/test-cloud-model.mjs

--- a/scripts/test-desktop-keys.mjs
+++ b/scripts/test-desktop-keys.mjs
@@ -1,0 +1,60 @@
+/**
+ * Does the Linux helper press the keys it was asked for?
+ *
+ * ⚠️ THIS IS THE ONE PART OF THE HELPER THAT CAN BE WRONG IN SILENCE. Everything
+ * else there moves a real mouse or fails loudly. A bad translation presses the
+ * wrong keys, exits 0, and tells the model it worked — and the model believes
+ * it, because there is nothing to believe otherwise.
+ *
+ * Two rules it has to keep:
+ *   · cmd MEANS THE COPY MODIFIER. A model told it is driving a desktop emits
+ *     "cmd+c"; mapping cmd to Super literally would open the GNOME overview.
+ *     Ctrl is what the user's own hands would press for the same intent.
+ *   · A MODIFIER WE DO NOT KNOW IS A REFUSAL, NOT A SHRUG. Dropping it and
+ *     pressing the bare key turns "fn+left" into "Left" and reports success.
+ */
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+const { xdotoolKey } = require('../gnome/radiant-control.cjs')
+
+let pass = 0, fail = 0
+const results = []
+const ok = (what, cond) => { cond ? pass++ : fail++; results.push(`  ${cond ? 'ok  ' : 'FAIL'} ${what}`) }
+const is = (what, got, want) => ok(`${what} → ${JSON.stringify(want)}${got === want ? '' : `, got ${JSON.stringify(got)}`}`, got === want)
+const refuses = (what, spec) => {
+  let threw = false
+  try { xdotoolKey(spec) } catch { threw = true }
+  ok(`${what} is refused rather than guessed`, threw)
+}
+
+// the intent-preserving translation
+is('cmd+c', xdotoolKey('cmd+c'), 'ctrl+c')
+is('command+a', xdotoolKey('command+a'), 'ctrl+a')
+is('meta+v', xdotoolKey('meta+v'), 'ctrl+v')
+is('ctrl+c stays itself', xdotoolKey('ctrl+c'), 'ctrl+c')
+is('super+l', xdotoolKey('super+l'), 'super+l')
+is('cmd+shift+z keeps both', xdotoolKey('cmd+shift+z'), 'ctrl+shift+z')
+is('opt maps to alt', xdotoolKey('opt+tab'), 'alt+Tab')
+
+// names the Swift helper accepts, spelled the way xdotool wants
+is('return', xdotoolKey('return'), 'Return')
+is('enter is the same key', xdotoolKey('enter'), 'Return')
+is('escape', xdotoolKey('escape'), 'Escape')
+is('esc', xdotoolKey('esc'), 'Escape')
+is('delete is backspace', xdotoolKey('delete'), 'BackSpace')
+is('forwarddelete is not', xdotoolKey('forwarddelete'), 'Delete')
+is('pagedown', xdotoolKey('pagedown'), 'Next')
+is('space', xdotoolKey('space'), 'space')
+is('f5 is uppercased', xdotoolKey('f5'), 'F5')
+is('a plain letter is left alone', xdotoolKey('a'), 'a')
+
+// ⚠️ the cases that used to lie
+refuses('an unknown modifier (fn)', 'fn+left')
+refuses('a typo for a modifier', 'ctrlx+c')
+refuses('a combo with no key at all', 'ctrl+')
+refuses('a bare plus', '+')
+refuses('an empty spec', '')
+
+console.log(results.join('\n'))
+console.log(`\n${pass}/${pass + fail} passed  ·  the desktop helper presses what it was asked for`)
+process.exit(fail ? 1 : 0)

--- a/server/computer-tools.js
+++ b/server/computer-tools.js
@@ -12,6 +12,16 @@ import { untrusted } from './tools.js'
 // the whole desktop (screen_*) and an automated browser (browser_*). Tools that
 // capture a view return an image so a vision model can see the result.
 
+// ⚠️ TELL THE MODEL WHICH DESKTOP IT IS ON, IN THE TOOL ITSELF. "Screenshot the
+// whole Mac desktop" and the example "cmd+c" are what a model reads before it
+// decides what to send, so on Linux they teach it the wrong modifier — and it
+// would go on emitting cmd+ combinations that mean nothing there. The helper
+// translates cmd to ctrl anyway, because a model that never read this still has
+// to be understood, but a description that is true costs nothing and is the
+// difference between working and working by fallback.
+const DESKTOP_NOUN = process.platform === 'darwin' ? 'Mac' : 'computer'
+const COPY_COMBO = process.platform === 'darwin' ? 'cmd+c' : 'ctrl+c'
+
 export const COMPUTER_TOOL_DEFS = [
   // ---- browser ----
   { name: 'browser_navigate', description: 'Open a URL in the controlled browser. Returns a screenshot of the page.', input_schema: { type: 'object', properties: { url: { type: 'string' } }, required: ['url'] } },
@@ -26,13 +36,13 @@ export const COMPUTER_TOOL_DEFS = [
   { name: 'browser_click_text', description: "Click an element in the user's own Chrome by its visible text or a CSS selector — more reliable than pixel coordinates, and it works on the signed-in browser. Give either text or selector.", input_schema: { type: 'object', properties: { text: { type: 'string' }, selector: { type: 'string' }, tabId: { type: 'number' } }, required: [] } },
   { name: 'browser_network', description: 'List the XHR/fetch JSON API calls the current site has made — its hidden API. Use it AFTER performing an action in the browser (search, load more, submit) to see the underlying requests (method, URL, headers, body, response sample), then recreate them as a plain HTTP client. Sensitive header values (cookies, tokens) are shown as present-but-hidden. Optional filter matches the URL.', input_schema: { type: 'object', properties: { filter: { type: 'string', description: 'Only calls whose URL contains this substring (optional).' } }, required: [] } },
   // ---- desktop ----
-  { name: 'screen_screenshot', description: 'Screenshot the whole Mac desktop. Coordinates for clicks are in this image space.', input_schema: { type: 'object', properties: {}, required: [] } },
+  { name: 'screen_screenshot', description: `Screenshot the whole ${DESKTOP_NOUN} desktop. Coordinates for clicks are in this image space.`, input_schema: { type: 'object', properties: {}, required: [] } },
   { name: 'screen_click', description: 'Click on the desktop at coordinates from the latest screen screenshot.', input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' }, button: { type: 'string', enum: ['left', 'right'] } }, required: ['x', 'y'] } },
   { name: 'screen_doubleclick', description: 'Double-click on the desktop.', input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' } }, required: ['x', 'y'] } },
   { name: 'screen_move', description: 'Move the mouse on the desktop without clicking.', input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' } }, required: ['x', 'y'] } },
   { name: 'screen_drag', description: 'Press and drag on the desktop from one point to another.', input_schema: { type: 'object', properties: { x1: { type: 'number' }, y1: { type: 'number' }, x2: { type: 'number' }, y2: { type: 'number' } }, required: ['x1', 'y1', 'x2', 'y2'] } },
   { name: 'screen_type', description: 'Type text on the desktop (into the focused app).', input_schema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] } },
-  { name: 'screen_key', description: 'Press a key or combo on the desktop, e.g. "return", "cmd+c".', input_schema: { type: 'object', properties: { keys: { type: 'string' } }, required: ['keys'] } },
+  { name: 'screen_key', description: `Press a key or combo on the desktop, e.g. "return", "${COPY_COMBO}".`, input_schema: { type: 'object', properties: { keys: { type: 'string' } }, required: ['keys'] } },
   { name: 'screen_scroll', description: 'Scroll on the desktop at a point. Positive dy scrolls up.', input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' }, dy: { type: 'number' } }, required: ['dy'] } }
 ]
 

--- a/server/computer.js
+++ b/server/computer.js
@@ -8,11 +8,27 @@ import { fileURLToPath } from 'url'
 const execFileP = promisify(execFile)
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// the compiled Swift helper; in the packaged app it's unpacked next to server/
+/**
+ * The desktop helper for THIS platform. In the packaged app it is unpacked
+ * beside server/.
+ *
+ * ⚠️ TWO HELPERS, ONE COMMAND LANGUAGE. native/radiant-control is Mach-O because
+ * CGEvent and Speech are Apple frameworks; gnome/radiant-control.cjs is a script
+ * because its whole job is driving xdotool and ImageMagick, and compiling that
+ * would buy nothing but a toolchain. They answer the same commands, so
+ * everything below this function is platform-blind.
+ */
+const HELPERS = {
+  darwin: ['native', 'radiant-control'],
+  linux: ['gnome', 'radiant-control.cjs']
+}
+
 export function helperPath () {
+  const rel = HELPERS[process.platform]
+  if (!rel) return null
   const candidates = [
-    path.join(__dirname, '..', 'native', 'radiant-control'),
-    path.join(process.resourcesPath || '', 'native', 'radiant-control')
+    path.join(__dirname, '..', ...rel),
+    path.join(process.resourcesPath || '', ...rel)
   ]
   return candidates.find(p => { try { return fs.existsSync(p) } catch { return false } }) || candidates[0]
 }
@@ -32,9 +48,18 @@ export function helperPath () {
 export async function permissions () {
   if (!helperAvailable()) return { helper: false, screenRecording: false, accessibility: false }
   try {
-    const out = await execFileP(helperPath(), ['permissions'], { timeout: 5000 })
+    const out = await runHelper(['permissions'], 5000)
     const j = JSON.parse(out.stdout.trim())
-    return { helper: true, screenRecording: Boolean(j.screenRecording), accessibility: Boolean(j.accessibility) }
+    // `reason` is optional and only the Linux helper sets it. macOS has a
+    // Settings pane to send people to; Linux has a missing package or a Wayland
+    // session, which are different problems with different answers, and "not
+    // granted" is not either of them.
+    return {
+      helper: true,
+      screenRecording: Boolean(j.screenRecording),
+      accessibility: Boolean(j.accessibility),
+      ...(j.reason ? { reason: String(j.reason) } : {})
+    }
   } catch {
     // An older helper has no `permissions` command. Say we do not know rather than
     // claiming either answer.
@@ -43,18 +68,21 @@ export async function permissions () {
 }
 
 /**
- * ⚠️ A MACH-O BINARY ON A LINUX BOX STILL EXISTS, SO existsSync IS NOT ENOUGH.
- * `extraResources` copies native/radiant-control into every packaged target,
- * and the file being there was the whole test — so off a Mac this said the
- * helper was present, execFile then failed with ENOEXEC, and the catch in
- * permissions() answered `{ helper: true, screenRecording: null }`. That is the
- * right answer for an OLD helper and the wrong one for a helper that can never
- * run here: Settings offered desktop control on a machine that has none. Same
- * shape as the bug the comment above records, one platform over.
+ * ⚠️ THE RIGHT HELPER FOR THIS PLATFORM, NOT ANY FILE OF THAT NAME. extraResources
+ * used to copy native/radiant-control into every packaged target, and the file
+ * being there was the whole test — so off a Mac this said the helper was
+ * present, execFile then failed with ENOEXEC, and permissions() answered
+ * `{ helper: true, screenRecording: null }` from its catch: the right reply for
+ * an OLD helper and a lie about one that cannot run here at all.
+ *
+ * helperPath() now returns null on a platform we ship nothing for, which is the
+ * honest answer and the one that keeps that bug from coming back by another
+ * route — a stale build, a hand-copied file, a helper for the wrong arch.
  */
 export function helperAvailable () {
-  if (process.platform !== 'darwin') return false
-  try { return fs.existsSync(helperPath()) } catch { return false }
+  const p = helperPath()
+  if (!p) return false
+  try { return fs.existsSync(p) } catch { return false }
 }
 
 let ensuredExec = false
@@ -64,9 +92,40 @@ function ensureExecutable () {
   ensuredExec = true
 }
 
+/**
+ * ⚠️ A SCRIPT HELPER RUNS ON OUR OWN RUNTIME, NEVER ON `env node`. The Linux
+ * helper starts `#!/usr/bin/env node`, and the AppImage bundles Electron — not
+ * node. On a machine without node installed the shebang fails with ENOENT, so
+ * desktop control would work on every developer's box and on nobody else's:
+ * exactly the class of bug you cannot see from where you built it.
+ *
+ * process.execPath is node when the server runs under node and Electron when it
+ * runs inside the app, and ELECTRON_RUN_AS_NODE turns the second into the first.
+ * One line, no new dependency, and the helper never has to be found on a PATH.
+ */
+async function runHelper (args, timeout) {
+  const helper = helperPath()
+  // ⚠️ SAY WHICH PLATFORM, NOT "cannot read properties of null". helperPath()
+  // returns null where we ship no helper, and every desktop.* method reaches
+  // here without asking helperAvailable() first — so this is the message a
+  // Windows user would otherwise never get instead of a TypeError.
+  if (!helper) throw new Error(`Radiant has no desktop helper for ${process.platform}.`)
+  const argv = args.map(String)
+  // Read the environment now rather than at import: a snapshot taken at module
+  // load cannot see anything set afterwards.
+  return helper.endsWith('.cjs')
+    ? execFileP(process.execPath, [helper, ...argv], { timeout, env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' } })
+    : execFileP(helper, argv, { timeout })
+}
+
 async function ctl (...args) {
+  // ⚠️ THE chmod BELONGS HERE AND ONLY HERE, exactly where it was. Moving it
+  // into runHelper() put it in permissions() too — a status poll that used to
+  // read the helper and now writes to it. Small, defensible, and not what the
+  // Mac did before, which is the only thing that matters for a claim that
+  // nothing about a Mac changes.
   ensureExecutable() // packaging can strip the exec bit off the bundled helper
-  const { stdout } = await execFileP(helperPath(), args.map(String), { timeout: 15000 })
+  const { stdout } = await runHelper(args, 15000)
   return stdout.trim()
 }
 
@@ -84,11 +143,20 @@ export async function screenSize () {
 // screencapture yields Retina pixels; we downscale to points so the model's
 // click coordinates map 1:1 onto CGEvent points.
 export async function screenshot () {
-  const { width } = await screenSize()
   const tmp = path.join(os.tmpdir(), `radiant-shot-${process.pid}.png`)
-  await execFileP('screencapture', ['-x', '-t', 'png', tmp], { timeout: 15000 })
-  // downscale to logical width with sips (built in), keeping aspect
-  await execFileP('sips', ['-Z', String(width), tmp], { timeout: 15000 }).catch(() => {})
+  if (process.platform === 'darwin') {
+    const { width } = await screenSize()
+    await execFileP('screencapture', ['-x', '-t', 'png', tmp], { timeout: 15000 })
+    // downscale to logical width with sips (built in), keeping aspect
+    await execFileP('sips', ['-Z', String(width), tmp], { timeout: 15000 }).catch(() => {})
+  } else {
+    // ⚠️ THE HELPER CAPTURES, NOT US. screencapture and sips are macOS binaries;
+    // asking the helper keeps the one rule that makes clicks land — the image and
+    // the coordinate space come from the same place. It captures the X root
+    // window, which is what screensize measures, so the mapping is 1:1 and there
+    // is nothing to downscale.
+    await ctl('screenshot', tmp)
+  }
   const data = fs.readFileSync(tmp)
   fs.unlink(tmp, () => {})
   return { dataB64: data.toString('base64'), mime: 'image/png' }

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1665,11 +1665,23 @@ function AgentPane ({ config, onSettings }) {
               and point at the half that does work. */}
         {comp?.platform && comp.platform !== 'darwin' ? (
           <div className='comp-stat'>
-            <span className='fit-badge fit-no'>— Desktop control</span>
+            <span className={comp.accessibility && comp.screenRecording ? 'key-ok' : 'fit-badge fit-no'}>
+              {comp.accessibility && comp.screenRecording ? '✓' : '—'} Desktop control
+            </span>
+            {/* ⚠️ NAME WHAT IS ACTUALLY IN THE WAY. There are two different
+                problems here and only one of them can be fixed: a missing
+                package is an apt install away, and a Wayland session is not —
+                it refuses synthetic input by design, so telling someone to
+                install something would send them after a fix that does not
+                exist. The helper reports which it is. */}
             <span className='desc'>
-              not available on {comp.platform === 'linux' ? 'Linux' : 'this platform'} — Radiant
-              moves the mouse, types and captures the screen through a macOS helper, and there is
-              no equivalent here yet. Browser control above needs none of it and works.
+              {comp.reason === 'wayland'
+                ? 'this is a Wayland session, which refuses one app typing into another by design. Log in with the X11 (Xorg) session to use it. Browser control above works either way.'
+                : comp.reason === 'missing:xdotool' ? 'install xdotool (apt install xdotool) and reopen this pane.'
+                  : comp.reason === 'missing:imagemagick' ? 'install ImageMagick (apt install imagemagick) and reopen this pane.'
+                    : comp.reason?.startsWith('missing:') ? 'install xdotool and ImageMagick (apt install xdotool imagemagick) and reopen this pane.'
+                      : comp.accessibility && comp.screenRecording ? 'the agent can see the screen, click and type.'
+                        : 'not available — the helper for this platform did not answer.'}
             </span>
           </div>
         ) : (<>


### PR DESCRIPTION
> **Stacks on #6 and #8.** The helper guard and the AppImage resource list live in #6; the Settings message this replaces comes from #8. Both are merged in, so the file list below is larger than this change. Review those first.

`gnome/radiant-control.cjs` is the X11 counterpart to `native/RadiantControl.swift`. It answers the same commands — `screensize`, `move`, `click`, `rightclick`, `doubleclick`, `drag`, `scroll`, `type`, `key`, `permissions` — so everything above `helperPath()` stays platform-blind. The iCloud commands are absent on purpose: they ask Foundation about a service this platform does not have.

**It is a script, not a binary, and that is the point.** The Swift helper must be Mach-O because CGEvent and Speech are Apple frameworks. Here the whole job is driving `xdotool` and ImageMagick, so compiling would buy nothing and cost a toolchain, a step in `dist`, and one more artefact that can ship for the wrong architecture — which is exactly how a Mach-O binary reached a Linux AppImage.

## Three things this found by being run rather than read

**⚠️ `getdisplaygeometry` is the primary monitor, not the screen.**

Measured on a two-monitor desktop (`HDMI-0` at `+0+0`, `DP-4` at `+2560+0`):

```
xdotool getdisplaygeometry  ->  2560 1440
import -window root         ->  5120x1440
xdotool mousemove 4000 700  ->  lands on the second screen, fine
```

The image the model sees and the space its clicks are read in would have disagreed by exactly one monitor — every click on the right-hand screen landing on the left one, silently, with nothing reporting an error. `screensize` now asks the root window (via `xdpyinfo` or `xrandr`), because that is the same thing we screenshot and so cannot drift from it.

**⚠️ A script helper must not run on `env node`.**

The shebang is `#!/usr/bin/env node` and the AppImage bundles Electron, not node. On my machine node is an nvm install under `~/.nvm` — a path a shell has and an app launched from the GNOME menu does not. Desktop control would have worked from a terminal and been broken from the applications menu, **on the same machine**, with nothing saying why.

`runHelper()` spawns `process.execPath` with `ELECTRON_RUN_AS_NODE` instead: node when the server runs under node, Electron when it runs inside the app, no PATH lookup at all. Verified by launching the packaged AppImage with `gtk-launch` — i.e. the menu path — and reading `/api/computer-status`.

**⚠️ `cmd` means "the copy modifier".**

A model told it is driving a desktop emits `cmd+c`, and mapping `cmd` to Super literally would open the GNOME overview. Ctrl is what the user's own hands would press for the same intent. The tool descriptions also name the local modifier now, so a model that reads them never needs the fallback.

## Honest about what it cannot do

Wayland is refused **with a reason** rather than failing quietly: XTest is blocked there by design, no flag changes it, and "install something" would send the user after a fix that does not exist. Missing packages are named individually. Settings reports whichever it is:

| state | what the pane says |
|---|---|
| working | ✓ Desktop control — the agent can see the screen, click and type. |
| Wayland | this is a Wayland session, which refuses one app typing into another by design. Log in with the X11 (Xorg) session to use it. |
| missing tool | install xdotool (`apt install xdotool`) and reopen this pane. |

## Verified on Debian 13 / GNOME / X11

- typing into a dialog arrives intact; `cmd+a` selects all and the replacement overwrites it
- a click computed from a screenshot lands on the right button of a window **on the second monitor**
- the packaged AppImage, launched from the menu, reports `{"desktop":true,"helper":true,"screenRecording":true,"accessibility":true}`
- `test-api` (which asserts the Swift helper's TCC calls), `test-drag`, `test-electron-safe`, `test-readme` and the other offline gates pass

## Not included

**Dictation.** It is Apple's on-device speech recognition; a Linux equivalent means whisper.cpp or vosk and a model download, which is a feature decision rather than a port. The 503 from #8 already says so honestly.

**The screenshot is not downscaled.** On macOS `sips` maps Retina pixels to CGEvent points; on X11 the capture and the click space are the same pixels, so scaling would break the 1:1 mapping rather than preserve it. The cost is that a 5120×1440 desktop produces a large image — real, and worth a follow-up, but not something to fix by guessing at a scaling scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
