### PR TITLE
The UI names the machine it is actually describing

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -909,6 +909,12 @@ export function publicConfig (cfg) {
     // The UI needs to SEE what was removed, or the library cannot offer it back
     // and "Remove" becomes a one-way door.
     serverHost: serverHost(),
+    // ⚠️ THE PLATFORM OF THE MACHINE RUNNING THE SERVER, WHICH IS THE ONE BEING
+    // DESCRIBED. Everything the UI says about "this Mac" — where models download,
+    // which agents are connected, whose screen the agent drives — is about the
+    // server's machine, not the one holding the window. serverHost already
+    // travels for exactly that reason; this is the same fact, one field over.
+    platform: process.platform,
     removedAgents: cfg.removedAgents || [],
     // ⚠️ SEND THE WHOLE DEFINITION, NOT JUST THE ID. With only ids the library
     // had to invent what it showed: a generic robot for every one of them, and a

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -651,6 +651,7 @@ function DesktopApp () {
       <WhatsNew />
       <div className='nav-backdrop' onClick={() => setNavOpen(false)} />
       <Sidebar
+        platform={config?.platform}
         section={view}
         onSection={setView}
         onOpenAgents={() => { setAgentView('library'); setSettingsTab('agents'); setSettingsOpen(true) }}
@@ -738,6 +739,7 @@ function DesktopApp () {
       ) : (
       <Chat
         serverHost={config.serverHost}
+        platform={config.platform}
         skills={config.skills || []}
         onAddSkill={addSkillToChat}
         onRemoveSkill={removeSkillFromChat}

--- a/src/api.js
+++ b/src/api.js
@@ -528,3 +528,23 @@ export async function saveToFile (name, mime, content) {
   setTimeout(() => URL.revokeObjectURL(url), 10000)
   return ''
 }
+
+/**
+ * What to call the machine running the server, in a sentence.
+ *
+ * ⚠️ THE SERVER'S MACHINE, NOT THE ONE HOLDING THE WINDOW. Everything the UI
+ * says about "this Mac" — where models download to, which agents are connected,
+ * whose screen the agent drives — describes the machine Radiant is running on,
+ * which you may be looking at from another one. That is why the platform rides
+ * along in /api/config beside serverHost rather than being read from the
+ * browser: navigator.platform would describe the wrong computer, confidently.
+ *
+ * Undefined until the config arrives, and 'Mac' is the right thing to say while
+ * waiting — it is what every existing string already said, so nothing flickers
+ * on the platform this was written for.
+ */
+export function deviceNoun (platform) {
+  if (platform === 'win32') return 'PC'
+  if (platform && platform !== 'darwin') return 'computer'
+  return 'Mac'
+}

--- a/src/components/Chat.jsx
+++ b/src/components/Chat.jsx
@@ -3,7 +3,7 @@ import Markdown from './Markdown.jsx'
 import { Icon } from './Icons.jsx'
 import { glyphColor } from '../theme.js'
 import { AgentGlyph } from './AgentIcons.jsx'
-import { api, getServer, apiUrl, authHeaders } from '../api.js'
+import { api, getServer, apiUrl, authHeaders, deviceNoun } from '../api.js'
 import { shouldDrainQueue } from '../queue.js'
 import { emptyDictation, applyDictationEvent, dictationText } from '../dictation.js'
 import { turnStatus, clock } from '../turnstatus.js'
@@ -894,7 +894,7 @@ export function GroupPicker ({ agents, onStart, onCancel }) {
   )
 }
 
-export default function Chat ({ session, live, todos = [], stats, approval, question, onAnswer, usage, error, models, agents = [], recipes = [], onSend, onStop, onApproval, onPickModel, onToggleTools, onToggleComputer, onTogglePlan, onSetCwd, onNew, onNewGroup, onTruncate, onRefreshModels, skillSuggestion, onReviewSkill, onDismissSuggestion, onOpenLibrary, rightOpen, onToggleRight, onMenu, approvalMode = 'ask', onCycleApproval, onFork, skills = [], onAddSkill, onRemoveSkill, serverHost, onSetEffort }) {
+export default function Chat ({ session, live, todos = [], stats, approval, question, onAnswer, usage, error, models, agents = [], recipes = [], onSend, onStop, onApproval, onPickModel, onToggleTools, onToggleComputer, onTogglePlan, onSetCwd, onNew, onNewGroup, onTruncate, onRefreshModels, skillSuggestion, onReviewSkill, onDismissSuggestion, onOpenLibrary, rightOpen, onToggleRight, onMenu, approvalMode = 'ask', onCycleApproval, onFork, skills = [], onAddSkill, onRemoveSkill, serverHost, platform, onSetEffort }) {
   // ⚠️ TOOLS RUN ON THE SERVER'S MAC. Computer control is the one where that is
   // dangerous rather than merely surprising: the mouse that moves, the keys that
   // get typed and the screen that is captured all belong to the machine running
@@ -1473,7 +1473,7 @@ export default function Chat ({ session, live, todos = [], stats, approval, ques
                   onClick={toggleDictation}
                   title={dictating ? 'Stop dictating' : 'Dictate'}
                   aria-pressed={dictating}
-                  data-tip={dictating ? 'Stop dictating' : 'Dictate — transcribed on this Mac'}
+                  data-tip={dictating ? 'Stop dictating' : `Dictate — transcribed on this ${deviceNoun(platform)}`}
                 ><Icon.mic size={15} />{dictating ? 'Listening' : 'Dictate'}</button>)}
               <button className='attach-btn' onClick={() => fileInputRef.current?.click()} title='Attach files or images' data-tip='Attach files or images'><Icon.plus size={17} /></button>
               <button className={'attach-btn' + (designBusy ? ' is-capturing' : '')} onClick={startDesign} disabled={designBusy} title='Design Mode' data-tip={'Design Mode — open a web page and click\nan element to capture its HTML, CSS &\na screenshot as context'}><Icon.target size={16} /></button>
@@ -1502,7 +1502,7 @@ export default function Chat ({ session, live, todos = [], stats, approval, ques
               <button
                 className={'pill-toggle' + (session.computerControl ? ' on' : '')}
                 onClick={onToggleComputer}
-                data-tip={'Computer control: the model drives the browser\nand desktop of ' + (onAnotherMac ? serverHost : 'this Mac') + '.\nNeeds a vision model + macOS permissions.\nClick to turn ' + (session.computerControl ? 'off' : 'on')}
+                data-tip={'Computer control: the model drives the browser\nand desktop of ' + (onAnotherMac ? serverHost : `this ${deviceNoun(platform)}`) + '.\nNeeds a vision model + the desktop permissions\nin Settings \u2192 Automation.\nClick to turn ' + (session.computerControl ? 'off' : 'on')}
               >
                 <Icon.monitor size={13} /> computer {session.computerControl ? 'on' : 'off'}
                   {onAnotherMac && session.computerControl && <span className='pill-where'> · {serverHost}</span>}

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { verdict, FIT_LABEL, FITS_WELL, FITS_TIGHT, FITS_NO, COMFORTABLE } from '../fit.js'
-import { api, startDownload, getDownloads, cancelDownload, streamQuantize, getServer, setServer, testServer, saveToFile } from '../api.js'
+import { api, startDownload, getDownloads, cancelDownload, streamQuantize, getServer, setServer, testServer, saveToFile, deviceNoun } from '../api.js'
 import { THEMES, MODES, FONTS, UI_SCALES, applyTheme, hexToOklch, accentHex, glyphColor } from '../theme.js'
 import { paletteWarnings, deriveAccent } from '../palette.js'
 import { MOTIONS } from './MotionBackground.jsx'
@@ -410,8 +410,8 @@ function DefaultModelBlock ({ config, onSettings }) {
       <div className='set-block-title'>Default model for new chats</div>
       <p className='hint' style={{ marginTop: 2 }}>
         What a new chat starts on when nothing else decides — an agent's own model, or a
-        project's, still wins. Set per Mac, so a Mac can default to the models it has
-        downloaded rather than ones it cannot run.
+        project's, still wins. Set per {deviceNoun(config?.platform)}, so each one can default to
+        the models it has downloaded rather than ones it cannot run.
       </p>
       <div className='model-pick-field' style={{ marginTop: 8 }}>
           <ModelPicker
@@ -425,7 +425,7 @@ function DefaultModelBlock ({ config, onSettings }) {
         </div>
       {current && !models.some(m => m.id === current) && (
         <div className='set-hint' style={{ marginTop: 6 }}>
-          <strong>{current}</strong> is set here but is not available on this Mac right now —
+          <strong>{current}</strong> is set here but is not available on this {deviceNoun(config?.platform)} right now —
           new chats will fall back until it is, or until you pick another.
         </div>
       )}
@@ -442,11 +442,14 @@ function ModelsPane ({ onModelsChanged, config, onSettings }) {
   // connected to another one is simply wrong, and it is how a pull started on a
   // laptop ends up filling a Mac in another room. Tony, on where a model lands:
   // "correct. thats what confused me."
+  // /api/system already describes the server's machine — hostname, chip, free
+  // space — so the word for it comes from the same answer as the rest.
+  const noun = deviceNoun(system?.platform)
   const onAnotherMac = Boolean(getServer().base)
   const serverMac = system?.hostname || (() => {
-    try { return new URL(getServer().base).hostname } catch { return 'the other Mac' }
+    try { return new URL(getServer().base).hostname } catch { return `the other ${noun}` }
   })()
-  const where = onAnotherMac ? serverMac : 'this Mac'
+  const where = onAnotherMac ? serverMac : `this ${noun}`
   const [local, setLocal] = useState({ running: true, models: [] })
   const [q, setQ] = useState('')
   const [sort, setSort] = useState('downloads')
@@ -522,7 +525,7 @@ function ModelsPane ({ onModelsChanged, config, onSettings }) {
       <h3>Local models</h3>
       {onAnotherMac && (
         <div className='set-hint' style={{ marginBottom: 10 }}>
-          You are using the Radiant on <strong>{serverMac}</strong>. Models download to that Mac
+          You are using the Radiant on <strong>{serverMac}</strong>. Models download to that {noun}
           and run there — not on this one — and the memory and free space below are its own.
           A download keeps going there even if you close this window.
         </div>
@@ -968,7 +971,7 @@ function AgentsPane ({ config, onConfigChange, initialView }) {
       </div>
       {external.length > 0 && (
         <div className='ext-agents'>
-          <div className='ext-agents-title'>Connected agents on this Mac</div>
+          <div className='ext-agents-title'>Connected agents on this {deviceNoun(config?.platform)}</div>
           <p className='ext-agents-sub'>Radiant found other agent apps you have installed. Connect a Hermes agent to chat with the real one — its own model, skills, and memory — right inside Radiant.</p>
           {external.map(ext => {
             const already = agents.some(a => (a.name || '').trim().toLowerCase() === (ext.name || '').trim().toLowerCase())
@@ -1651,7 +1654,7 @@ function AgentPane ({ config, onSettings }) {
       <ChromeAttachBlock />
 
       <div className='set-block'>
-        <div className='set-block-title'>What works on {config?.serverHost || 'this Mac'}</div>
+        <div className='set-block-title'>What works on {config?.serverHost || `this ${deviceNoun(config?.platform)}`}</div>
         <div className='comp-stat'>
           <span className={comp?.browser ? 'key-ok' : 'fit-badge fit-no'}>{comp?.browser ? '✓' : '—'} Browser control</span>
           <span className='desc'>drives your system Chrome. Nothing to set up.</span>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -4,7 +4,7 @@ import HoldButton from './HoldButton.jsx'
 import { glyphColor } from '../theme.js'
 import { AgentGlyph } from './AgentIcons.jsx'
 import { isImported } from './Chat.jsx'
-import { api, saveToFile, getServer } from '../api.js'
+import { api, saveToFile, getServer, deviceNoun } from '../api.js'
 
 function UsageChip () {
   const [items, setItems] = useState(null)
@@ -238,7 +238,7 @@ function SessionRow ({ s, showAgent = true, ctx }) {
 // index in this list, so reordering it moves the pill; it is not decoration.
 const WORK = ['tasks', 'loops', 'graph']
 
-export default function Sidebar ({ section = 'chat', onSection, onOpenAgents, sessions, activeId, working, onOpen, onNew, onNewGroup, onDelete, onArchive, onRename, onPin, agents = [], projects = [], projectsError = null, onNewProject, onRenameProject, onDeleteProject, onMoveSession, onSettings, mode, onToggleMode, updateInfo, onUpdate, onCloseNav }) {
+export default function Sidebar ({ section = 'chat', onSection, onOpenAgents, sessions, activeId, working, onOpen, onNew, onNewGroup, onDelete, onArchive, onRename, onPin, agents = [], projects = [], projectsError = null, onNewProject, onRenameProject, onDeleteProject, onMoveSession, onSettings, mode, onToggleMode, updateInfo, onUpdate, onCloseNav, platform }) {
   const agentOf = id => agents.find(a => a.id === id)
   const [width, setWidth] = useState(() => {
     const saved = Number(localStorage.getItem('radiant.sidebarWidth'))
@@ -594,7 +594,7 @@ export default function Sidebar ({ section = 'chat', onSection, onOpenAgents, se
             answering it meant opening another screen. */}
         {version && (
           remoteBase
-            ? <span className='sidebar-version is-remote' title={`Showing Radiant ${version} on ${remoteHost}. Settings → Devices to use this Mac instead.`}>
+            ? <span className='sidebar-version is-remote' title={`Showing Radiant ${version} on ${remoteHost}. Settings → Devices to use this ${deviceNoun(platform)} instead.`}>
                 {remoteHost} · {version}
               </span>
             : <span className='sidebar-version' title={`Radiant ${version}`}>{version}</span>


### PR DESCRIPTION
"this Mac" appears about 250 times. **Most of those are correct and stay.** The What's New list is a history of what shipped; the iCloud pane only renders where iCloud exists, and "Turn this on once per Mac" sits inside it. Rewriting them would be replacing true sentences with vaguer ones.

This changes the ones a reader on another platform actually reaches, and it changes them **from one fact rather than by find-and-replace**: `publicConfig()` carries `platform` beside `serverHost`, and `deviceNoun()` turns it into a word.

### ⚠️ The server's machine, not the one holding the window

Every one of these sentences describes where Radiant is *running* — where models download to, which agents are connected, whose desktop the agent drives — and you may be looking at it from somewhere else. That is the same reason `serverHost` already travels, and it is why the platform rides in the config rather than being read from the browser: `navigator.platform` would describe the wrong computer, confidently, and only for the user least likely to notice.

The word matches `server/platform.js`'s `deviceNoun` (#5) so the two halves of the app cannot drift into calling the same machine different things.

### Changed

| was | now |
|---|---|
| "Set per Mac, so a Mac can default…" | "Set per computer, so each one can default…" |
| the Models pane's `where` | "on this computer" |
| "Models download to that Mac" | …that computer |
| "is not available on this Mac right now" | …this computer… |
| "Connected agents on this Mac" | …this computer |
| "What works on this Mac" (fallback) | …this computer |
| the Sidebar's remote-server tooltip | … |
| the Dictate tooltip | … |
| the computer-control tooltip | also said *"Needs a vision model + macOS permissions"* — now points at Settings → Automation, which is where the answer is on every platform |

All verified on screen, not in the diff — the Models pane now reads "Set per computer", "on this computer." and "ON THIS COMPUTER · 10 INSTALLED".

### Left alone on purpose

The **Read me** (`GUIDE`) and **What's New**. Both are prose about what Radiant does and when it changed, they are long, and editing them here would bury this change inside a rewrite of the product copy — which is yours to make, not a side effect of a port.

One line in my screenshot is still wrong and is **not** this PR's: `63 GB unified memory · 24 cores · macOS · 480 GB free on disk`. That is fixed in #5.

### Gates

`test-readme`, `test-contrast`, `test-api`, `test-drag`, `test-electron-safe` and the other offline gates pass. Based on `2f56a38`; independent of the other five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
