### PR TITLE
A Linux release actually reaches somebody

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,0 +1,103 @@
+# Build the Linux AppImage and attach it to a release that already exists.
+#
+# ⚠️ THIS DOES NOT CHANGE HOW RADIANT IS RELEASED. `npm run release` still runs
+# on the Mac, still notarises, still uploads the dmg, the zip, latest-mac.yml and
+# the stable radiant.dmg, and still verifies the public download. This starts
+# AFTER that, when the release is published, and adds two files to it. Nothing
+# here can alter the Mac assets or the release notes, and if it fails the Mac
+# release is already out and unaffected.
+#
+# ⚠️ AND IT IS THE ONLY REASON A LINUX BUILD REACHES ANYONE. electron-builder
+# cannot cross-compile an AppImage from macOS, so without a Linux runner the
+# target in package.json produces an artefact that only ever exists on the
+# machine that ran it, and server/updater.js goes on finding no asset for a
+# Linux user. This is the missing half.
+name: Linux release
+
+on:
+  release:
+    types: [published]
+  # For rebuilding a tag by hand — a failed run, or a release cut before this
+  # workflow existed.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to attach the AppImage to (e.g. v0.7.8)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  appimage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # node-pty ships prebuilds for darwin and win32 only, so on Linux it is
+      # compiled here. xvfb is for the smoke test below, not for the build.
+      - name: System build deps
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends xvfb
+
+      - run: npm ci
+
+      - run: npm run dist:linux
+
+      # ⚠️ A BUILD THAT EXITS 0 IS NOT A BUILD THAT RUNS. This is the Linux
+      # counterpart of scripts/test-smoke.mjs, which boots the built app and asks
+      # it a question — a gate that only checks the file exists would have passed
+      # for every packaging mistake made getting here, including a helper for the
+      # wrong architecture and a native module built against the wrong ABI.
+      - name: Smoke test the AppImage
+        run: |
+          set -euo pipefail
+          APP=$(ls release/Radiant-*.AppImage)
+          echo "booting $APP"
+          xvfb-run -a "$APP" --appimage-extract-and-run --no-sandbox > /tmp/smoke.log 2>&1 &
+          for i in $(seq 1 40); do
+            # a refused connection here is the app still starting, not a failure
+            if curl -fs http://127.0.0.1:5834/api/config > /tmp/config.json 2>/dev/null; then break; fi
+            sleep 2
+          done
+          if ! test -s /tmp/config.json; then
+            echo "the packaged app never answered on 5834"; tail -50 /tmp/smoke.log; exit 1
+          fi
+          node -e '
+            const c = require("/tmp/config.json")
+            if (!Array.isArray(c.providers) || !c.providers.length) throw new Error("no providers in the served config")
+            if (!c.serverHost) throw new Error("the served config has no serverHost")
+            console.log("the packaged app booted and answered")
+          '
+
+      - name: Attach to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # latest-linux.yml is what the in-app updater reads; without it the
+          # AppImage is downloadable and never updates itself.
+          gh release upload "$TAG" release/Radiant-*.AppImage release/latest-linux.yml --clobber
+
+      # The same check release.mjs makes for the dmg, for the same reason: HEAD
+      # returns 404 on GitHub's asset CDN even for a healthy asset, so this is a
+      # GET, and an asset nobody can fetch is not a release.
+      - name: Prove a stranger can download it
+        env:
+          TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          NAME=$(basename $(ls release/Radiant-*.AppImage))
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${NAME}"
+          for i in $(seq 1 6); do
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -r 0-99 -L "$URL")
+            if [ "$CODE" = "200" ] || [ "$CODE" = "206" ]; then echo "✓ $URL downloads"; exit 0; fi
+            sleep 5
+          done
+          echo "✗ $URL does not download"; exit 1


### PR DESCRIPTION
> **Stacks on #6**, which adds `dist:linux`. Nothing else depends on it.

In #9 I said producing a Linux artefact needs a Linux builder and that this was a decision about CI rather than a patch to `release.mjs`. **This is that decision written down as one option — take it or leave it.** `release.mjs` is still untouched.

electron-builder cannot cross-compile an AppImage from macOS, so `dist:linux` produces an artefact that exists only on the machine that ran it. Without a Linux runner the target is real and the release is not: `server/updater.js` goes on finding no asset for a Linux user, and the AppImage is something you can build and nobody can download.

### ⚠️ This does not change how Radiant is released

`npm run release` still runs on the Mac, still notarises, still uploads the dmg, the zip, `latest-mac.yml` and the stable `radiant.dmg` the website's button points at, and still verifies the public download.

This starts **after** that, on `release: published`, and adds two files. It cannot touch the Mac assets or the notes, and if it fails, the Mac release is already out and unaffected. `workflow_dispatch` takes a tag, for a failed run or a release cut before this existed.

### Two gates, both borrowed from release.mjs

**A build that exits 0 is not a build that runs.** The AppImage is booted under xvfb and asked for `/api/config` — the Linux counterpart of `test-smoke.mjs`. A check that the file exists would have passed for every packaging mistake made getting here, including a helper for the wrong architecture and a native module built against the wrong ABI.

Verified locally against a real AppImage before writing it into the workflow:

```
SMOKE OK — booted and answered; serverHost=samirb3, providers=21
```

**A public download must be fetched, not assumed.** Same rule as `release.mjs`, same GET rather than HEAD, for the same reason you recorded there.

`latest-linux.yml` is uploaded beside the AppImage. Without it the download works and never updates itself, which is the quieter half of the same problem.

### Checked rather than assumed

- `npm ci` against the committed lockfile: resolves 581 packages cleanly. The `license` field disagreeing with `package.json` (`FSL-1.1-MIT` vs `MIT`) does **not** stop it — worth knowing, since it looked like it might.
- Node 22, matching what Electron 43 bundles.
- `node-pty` ships prebuilds for darwin and win32 only, so it compiles on the runner. `ubuntu-latest` can already do that.
- The YAML parses, and the smoke block was run end to end locally with a real display standing in for xvfb.

### What I could not verify

The workflow has never run on GitHub's runners — I have no way to trigger Actions on your repo. The build, the smoke test and the download check were each exercised locally; the parts I cannot prove are the runner's own environment and the `gh release upload` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
